### PR TITLE
Modification of dbget() for FunctionalFile case

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1360,8 +1360,7 @@ switch contextName
         sStudy = sql_query(sqlConn, 'select', 'Study', 'Id', struct('FileName', StudyFile));
         % If data file instead on Study file
         if isempty(sStudy)
-            sFile = sql_query(sqlConn, 'select', 'FunctionalFile', 'Study', ...
-                struct('FileName', StudyFile));
+            sFile = db_get('FunctionalFile', sqlConn, StudyFile, 'Study');
             if ~isempty(sFile)
                 iStudy = sFile.Study;
             end

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1402,7 +1402,7 @@ switch contextName
             % Get study 
             iStudy = iStudies(i);
             [iChannel, iChanStudy] = db_get('ChannelFromStudy', sqlConn, iStudy);
-            sChannel = db_get('FunctionalFile', sqlConn, 'channel', iChannel);
+            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
             if ~isempty(sChannel)
                 iChanStudies = [iChanStudies, iChanStudy];
                 sListChannel = [sListChannel, sChannel];
@@ -1422,7 +1422,7 @@ switch contextName
         sFile = sql_query(sqlConn, 'select', 'FunctionalFile', ...
             {'Id', 'Study', 'Type'}, struct('FileName', varargin{2}));
         if strcmpi(sFile.Type, 'channel')
-            sChannel = db_get('FunctionalFile', sqlConn, 'channel', sFile.Id);
+            [~, sChannel] = db_get('FunctionalFile', sqlConn, sFile.Id);
             sql_close(sqlConn);
         else
             sql_close(sqlConn);

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1418,8 +1418,7 @@ switch contextName
     case 'ChannelModalities'
         % Get channel from input file
         sqlConn = sql_connect();
-        sFile = sql_query(sqlConn, 'select', 'FunctionalFile', ...
-            {'Id', 'Study', 'Type'}, struct('FileName', varargin{2}));
+        sFile = db_get('FunctionalFile', sqlConn, varargin{2}, {'Id', 'Study', 'Type'});
         if strcmpi(sFile.Type, 'channel')
             [~, sChannel] = db_get('FunctionalFile', sqlConn, sFile.Id);
             sql_close(sqlConn);

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -230,8 +230,7 @@ switch contextName
                 for iCat = 1:length(categories)
                     field = ['i' categories{iCat}];
                     if ~isempty(sStudy.(field)) && isnumeric(sStudy.(field))
-                        sFile = sql_query(sqlConn, 'select', 'FunctionalFile', ...
-                            'FileName', struct('Id', sStudy.(field)));
+                        sFile = db_get('FunctionalFile', sqlConn, sStudy.(field), 'FileName');
                         if ~isempty(sFile)
                             sStudy.(field) = sFile.FileName;
                         end
@@ -391,8 +390,7 @@ switch contextName
                     selectedFiles{iCat} = sStudies(i).(field);
                 elseif ~isempty(sStudies(i).(field)) && isnumeric(sStudies(i).(field))
                     % Get FileName with previous file ID before it's deleted
-                    sFile = sql_query(sqlConn, 'select', 'FunctionalFile', ...
-                        'FileName', struct('Id', sStudies(i).(field)));
+                    sFile = db_get('FunctionalFile', sqlConn, sStudies(i).(field), 'FileName');
                     if ~isempty(sFile)
                         selectedFiles{iCat} = sFile.FileName;
                     end

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -135,7 +135,7 @@ if isAnatomy
 else
     % Get parent file
     if ~isempty(ParentFile)
-        sParent = sql_query(sqlConn, 'select', 'FunctionalFile', {'FileName', 'Type'}, struct('Id', ParentFile));
+        sParent = db_get('FunctionalFile', sqlConn, ParentFile, {'FileName', 'Type'});
         if strcmpi(sParent.Type, 'folder')
             ParentFolder = sParent.FileName;
         else
@@ -162,17 +162,17 @@ if ismember(fileType, {'subjectimage', 'channel', 'noisecov', 'ndatacov'})
 %                 delfile = bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.Anatomy(1).FileName);
 %             end
         case 'channel'
-            sChannel = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Study', iTarget, 'Type', 'channel'));
+            [~, sChannel] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'));
             if ~isempty(sChannel)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sChannel.FileName);
             end
         case 'noisecov'
-            sNoiseCov = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Study', iTarget, 'Type', 'noisecov'));
+            [~, sNoiseCov] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'));
             if ~isempty(sNoiseCov)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sNoiseCov(1).FileName);
             end
         case 'ndatacov'
-            sDataCov = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Study', iTarget, 'Type', 'ndatacov'));
+            [~, sDataCov] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'));
             if ~isempty(sDataCov)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sDataCov(1).FileName);
             end

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -162,17 +162,17 @@ if ismember(fileType, {'subjectimage', 'channel', 'noisecov', 'ndatacov'})
 %                 delfile = bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.Anatomy(1).FileName);
 %             end
         case 'channel'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'));
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile.FileName);
             end
         case 'noisecov'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'));
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end
         case 'ndatacov'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'));
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -162,19 +162,19 @@ if ismember(fileType, {'subjectimage', 'channel', 'noisecov', 'ndatacov'})
 %                 delfile = bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.Anatomy(1).FileName);
 %             end
         case 'channel'
-            [~, sChannel] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'));
-            if ~isempty(sChannel)
-                delfile = bst_fullfile(ProtocolInfo.STUDIES, sChannel.FileName);
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'));
+            if ~isempty(sFile)
+                delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile.FileName);
             end
         case 'noisecov'
-            [~, sNoiseCov] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'));
-            if ~isempty(sNoiseCov)
-                delfile = bst_fullfile(ProtocolInfo.STUDIES, sNoiseCov(1).FileName);
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'));
+            if ~isempty(sFile)
+                delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end
         case 'ndatacov'
-            [~, sDataCov] = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'));
-            if ~isempty(sDataCov)
-                delfile = bst_fullfile(ProtocolInfo.STUDIES, sDataCov(1).FileName);
+            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'));
+            if ~isempty(sFile)
+                delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end
     end
     % Replace file

--- a/toolbox/db/db_add_data.m
+++ b/toolbox/db/db_add_data.m
@@ -86,7 +86,7 @@ if isempty(iItem)
         queryCond.ExtraStr1 = sNew.ExtraStr1;
     end
     
-    sFiles = sql_query(sqlConn, 'select', 'FunctionalFile', 'Name', queryCond);
+    sFiles = db_get('FunctionalFile', sqlConn, queryCond, 'Name');
     if ~isempty(sFiles)
         Comment = file_unique(sNew.Name, {sFiles.Name});
         % Modify input file
@@ -100,7 +100,7 @@ if isempty(iItem)
     db_set(sqlConn, 'FunctionalFile', 'insert', sNew);
 else
     % Delete replaced file
-    sOld = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Id', iItem));
+    sOld = db_get('FunctionalFile', sqlConn, iItem, 'FileName');
     if ~isempty(sOld)
         file_delete(bst_fullfile(ProtocolInfo.STUDIES, sOld.FileName), 1);
     end

--- a/toolbox/db/db_add_subfolder.m
+++ b/toolbox/db/db_add_subfolder.m
@@ -73,6 +73,7 @@ for iStudy = iStudies
         
         % Get parent name
         sParent = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Id', iParent));
+        sParent = db_get('FunctionalFile', sqlConn, iParent, 'FileName');
         sFile.FileName = bst_fullfile(sParent.FileName, FolderName);
     else
         % Get Subject & Study names

--- a/toolbox/db/db_add_subfolder.m
+++ b/toolbox/db/db_add_subfolder.m
@@ -72,7 +72,6 @@ for iStudy = iStudies
         sFile.ParentFile = iParent;
         
         % Get parent name
-        sParent = sql_query(sqlConn, 'select', 'FunctionalFile', 'FileName', struct('Id', iParent));
         sParent = db_get('FunctionalFile', sqlConn, iParent, 'FileName');
         sFile.FileName = bst_fullfile(sParent.FileName, FolderName);
     else

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -264,7 +264,7 @@ switch contextName
         end
         sItems = [];
         
-        % If output expeted, all field requested, and all sFiles are same Type     
+        % If output expected, all fields requested, and all sFiles are same Type     
         if nargout > 1 && isequal(fields, '*') && length(unique({sFiles(:).Type})) == 1
             nFiles = length(sFiles);
             sItems = repmat(db_template(sFiles(1).Type), 1, nFiles);

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -249,14 +249,11 @@ switch contextName
             else
                 condQuery.Id = iFiles(i);
             end
-            if ~isempty(type)
-                condQuery.Type = type;
-            end
             sFiles(i) = sql_query(sqlConn, 'select', 'functionalfile', fields, condQuery);
             if i == 1
-                sItems = repmat(db_template(sFiles(i).Type), 1, nFiles);
+                sItems = repmat(db_template(sFiles(1).Type), 1, nFiles);
             end        
-            sItems(i) = getFuncFileStruct(type, sFiles(i));
+            sItems(i) = getFuncFileStruct(sFiles(i).Type, sFiles(i));
         end
  
         varargout{1} = sFiles;

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -229,7 +229,7 @@ switch contextName
         fields = '*';
         condQuery = struct();
         if length(args) > 1
-           fields = {2};
+            fields = args{2};
         end
         
         if isstruct(iFiles)

--- a/toolbox/db/lock_acquire.m
+++ b/toolbox/db/lock_acquire.m
@@ -54,7 +54,7 @@ end
 % Get file ID
 if nargin > 3
     if ischar(FileId)
-        sFile = sql_query(sqlConnection, 'select', 'functionalfile', 'Id', struct('FileName', FileId));
+        sFile = db_get('functionalfile', sqlConnection, FileId, 'Id');
         FileId = sFile.Id;
     end
 else

--- a/toolbox/db/lock_read.m
+++ b/toolbox/db/lock_read.m
@@ -81,7 +81,7 @@ end
 if isempty(sLock) && ~isempty(FileId)
     ParentId = FileId;
     while 1
-        sParent = sql_query(sqlConnection, 'select', 'FunctionalFile', 'ParentFile', struct('Id', ParentId));
+        sParent = db_get('FunctionalFile', sqlConnection, ParentId, 'ParentFile');
         if isempty(sParent) || isempty(sParent.ParentFile)
             break;
         end

--- a/toolbox/gui/panel_nodelist.m
+++ b/toolbox/gui/panel_nodelist.m
@@ -722,7 +722,7 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
         result.close();
         % Get channel file
         if iChannel ~= 0
-            sChannel = db_get('FunctionalFile', sqlConn, 'channel', iChannel);
+            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
         else
             sChannel = [];
         end
@@ -747,19 +747,19 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
             % Data or results
             switch (ProcessType)
                 case 'data'
-                    sData = db_get('FunctionalFile', sqlConn, 'Data', iItems(i));
+                    [~, sData] = db_get('FunctionalFile', sqlConn, iItems(i));
                     sFiles(i).FileName = file_win2unix(sData.FileName);
                     sFiles(i).Comment  = sData.Comment;
                     if strcmpi(sData.DataType, 'raw')
                         sFiles(i).FileType = 'raw';
                     end
                 case 'results'
-                    sResult = db_get('FunctionalFile', sqlConn, 'Result', iItems(i));
+                    [~, sResult] = db_get('FunctionalFile', sqlConn, iItems(i));
                     sFiles(i).FileName = file_win2unix(sResult.FileName);
                     sFiles(i).Comment  = sResult.Comment;
                     sFiles(i).DataFile = file_win2unix(sResult.DataFile);
                 case 'timefreq'
-                    sTimefreq = db_get('FunctionalFile', sqlConn, 'Timefreq', iItems(i));
+                    [~, sTimefreq] = db_get('FunctionalFile', sqlConn, iItems(i));
                     % Do not accept TF/sources, because it's impossible to get the full matrix [nSources x nTime x nFrequencies]
                     if isFirstWarning && strcmpi(sTimefreq.DataType, 'results') && ~isempty(strfind(sTimefreq.FileName, '_KERNEL_'))
                         isFirstWarning = 0;
@@ -778,11 +778,11 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
                     sFiles(i).Comment  = sTimefreq.Comment;
                     sFiles(i).DataFile = file_win2unix(sTimefreq.DataFile);
                 case 'matrix'
-                    sMatrix = db_get('FunctionalFile', sqlConn, 'Matrix', iItems(i));
+                    [~, sMatrix] = db_get('FunctionalFile', sqlConn, iItems(i));
                     sFiles(i).FileName = file_win2unix(sMatrix.FileName);
                     sFiles(i).Comment  = sMatrix.Comment;
                 case {'pdata','presults','ptimefreq','pmatrix'}
-                    sStat = db_get('FunctionalFile', sqlConn, 'Stat', iItems(i));
+                    [~, sStat] = db_get('FunctionalFile', sqlConn, iItems(i));
                     sFiles(i).FileName = file_win2unix(sStat.FileName);
                     sFiles(i).Comment  = sStat.Comment;
                 otherwise

--- a/toolbox/gui/panel_protocols.m
+++ b/toolbox/gui/panel_protocols.m
@@ -945,7 +945,7 @@ function nodeFound = GetNode( nodeRoot, nodeTypes, iStudy, iFile )
     if (nargin <= 2)
         % Find file in database
         FileName = nodeTypes;
-        sFile = sql_query([], 'select', 'FunctionalFile', {'Id', 'Study'}, struct('FileName', file_short(FileName)));
+        sFile = db_get('FunctionalFile', file_short(FileName), {'Id', 'Study'});
         if isempty(sFile)
             return
         end

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -1545,8 +1545,6 @@ function sInputs = GetInputStruct(FileNames)
     end
     % Output structure
     sInputs = repmat(db_template('processfile'), 1, length(FileNames));
-    % Get file type for the first file
-    FileType = file_gettype(FileNames{1});
     % Remove the full path
     ProtocolInfo = bst_get('ProtocolInfo');
     FileNames = cellfun(@(c)strrep(c, [ProtocolInfo.STUDIES, filesep], ''), FileNames, 'UniformOutput', 0);
@@ -1588,7 +1586,7 @@ function sInputs = GetInputStruct(FileNames)
         [sInputs(iGroupFiles).SubjectFile] = deal(file_win2unix(SubjectFile));
         % Get channel file
         if iChannel ~= 0
-            sChannel = db_get('FunctionalFile', sqlConn, 'channel', iChannel);
+            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
             [sInputs(iGroupFiles).ChannelFile]  = deal(file_win2unix(sChannel.FileName));
             [sInputs(iGroupFiles).ChannelTypes] = deal(sChannel.Modalities);
         end
@@ -1599,7 +1597,7 @@ function sInputs = GetInputStruct(FileNames)
         % Get item info
         for iItem = 1:length(iGroupFiles)
             iInput = iGroupFiles(iItem);
-            [sItem, sFile] = db_get('FunctionalFile', sqlConn, FileType, GroupFileNames{iItem});
+            [sFile, sItem] = db_get('FunctionalFile', sqlConn, GroupFileNames{iItem});
             
             % Skip if file not found in database
             if isempty(sItem)
@@ -1607,12 +1605,12 @@ function sInputs = GetInputStruct(FileNames)
             end
             
             % Extract input type
-            if strcmpi(FileType, 'data') && strcmpi(sItem.DataType, 'raw')
+            if strcmpi(sFile.Type, 'data') && strcmpi(sItem.DataType, 'raw')
                 InputType = 'raw';
-            elseif strcmpi(FileType, 'link')
+            elseif strcmpi(sFile.Type, 'link')
                 InputType = 'results';
             else
-                InputType = FileType;
+                InputType = sFile.Type;
             end
             
             % Fill structure

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1339,7 +1339,7 @@ switch (lower(action))
                 % Get study description
                 iStudy = bstNodes(1).getStudyIndex();
                 iData = bstNodes(1).getItemIndex();
-                sData = db_get('FunctionalFile', 'Data', iData);
+                [~, sData] = db_get('FunctionalFile', iData);
                 iSubject = db_get('SubjectFromStudy', iStudy);
                 sSubject = bst_get('Subject', iSubject);
                 % Data type

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -177,7 +177,7 @@ try
                 % Check for bad trials
                 if ~GetBadTrials
                     % Get study
-                    sItem = db_get('FunctionalFile', 'data', nodeFileNames{iNode});
+                    [~, sItem] = db_get('FunctionalFile', nodeFileNames{iNode});
                     % Ignore bad trials
                     if sItem.BadTrial
                         continue;

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -544,7 +544,7 @@ if ~isempty(iTargetStudies)
                 if ~GetBadTrials
                     qryCond.ExtraNum = 0;
                 end
-                sFiles = sql_query([], 'select', 'FunctionalFile', 'Id', qryCond);
+                sFiles = db_get('FunctionalFile', qryCond, 'Id');
                 
                 % Add data files to list
                 if ~isempty(sFiles)

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -177,9 +177,9 @@ try
                 % Check for bad trials
                 if ~GetBadTrials
                     % Get study
-                    [~, sItem] = db_get('FunctionalFile', nodeFileNames{iNode});
+                    [~, sData] = db_get('FunctionalFile', nodeFileNames{iNode});
                     % Ignore bad trials
-                    if sItem.BadTrial
+                    if sData.BadTrial
                         continue;
                     end
                 end

--- a/toolbox/tree/tree_set_channelflag.m
+++ b/toolbox/tree/tree_set_channelflag.m
@@ -59,15 +59,15 @@ else
     iStudies = [sFiles(:).Study];
     iFiles   = [sFiles(:).Id];
     
-    sqlConn = sql_connect();
-    for iFile = 1:length(DataFiles)
-        sFile = sql_query(sqlConn, 'select', 'FunctionalFile', {'Id', 'Study'}, struct('FileName', DataFiles{iFile}));
-        if ~isempty(sFile)
-            iStudies(end + 1) = sFile.Study;
-            iFiles(end + 1)   = sFile.Id;
-        end
-    end
-    sql_close(sqlConn);
+%     sqlConn = sql_connect();
+%     for iFile = 1:length(DataFiles)
+%         sFile = sql_query(sqlConn, 'select', 'FunctionalFile', {'Id', 'Study'}, struct('FileName', DataFiles{iFile}));
+%         if ~isempty(sFile)
+%             iStudies(end + 1) = sFile.Study;
+%             iFiles(end + 1)   = sFile.Id;
+%         end
+%     end
+%     sql_close(sqlConn);
 end
 
 % No files found : return
@@ -127,12 +127,11 @@ for i = 1:length(iStudies)
     % Get data file
     iStudy = iStudies(i);
     iFile  = iFiles(i);
-    sData = sql_query(sqlConn, 'select', 'FunctionalFile', ...
-        {'Type', 'FileName', 'Name', 'SubType'}, struct('Id', iFile));
-    if isempty(sData)
+    sFile = db_get('FunctionalFile', sqlConn, iFile, {'Type', 'FileName', 'Name', 'SubType'});
+    if isempty(sFile)
         continue;
     end
-    isRaw = strcmpi(sData.Type, 'data') && strcmpi(sData.SubType, 'raw');
+    isRaw = strcmpi(sFile.Type, 'data') && strcmpi(sFile.SubType, 'raw');
     if isRaw && isDetectFlat
         if isFirstError
             bst_error('This process can only be applied on imported recordings.', 'Detect flat channels', 0);
@@ -140,7 +139,7 @@ for i = 1:length(iStudies)
         end
         continue;
     end
-    DataFile = sData.FileName;
+    DataFile = sFile.FileName;
     DataFileFull = file_fullpath(DataFile);
     
     % Get channel file
@@ -190,7 +189,7 @@ for i = 1:length(iStudies)
     warning on MATLAB:load:variableNotFound
     
     % Build information string
-    strCond = [' - ' bst_fileparts(sData.FileName) '/' sData.Name ': '];
+    strCond = [' - ' bst_fileparts(sFile.FileName) '/' sFile.Name ': '];
     % Find bad channels
     iBad = find(DataMat.ChannelFlag == -1);
     % Add bad channels to string

--- a/toolbox/tree/tree_set_channelflag.m
+++ b/toolbox/tree/tree_set_channelflag.m
@@ -58,16 +58,6 @@ else
     sFiles = db_get('FunctionalFile', bstNodes, {'Id', 'Study'});
     iStudies = [sFiles(:).Study];
     iFiles   = [sFiles(:).Id];
-    
-%     sqlConn = sql_connect();
-%     for iFile = 1:length(DataFiles)
-%         sFile = sql_query(sqlConn, 'select', 'FunctionalFile', {'Id', 'Study'}, struct('FileName', DataFiles{iFile}));
-%         if ~isempty(sFile)
-%             iStudies(end + 1) = sFile.Study;
-%             iFiles(end + 1)   = sFile.Id;
-%         end
-%     end
-%     sql_close(sqlConn);
 end
 
 % No files found : return

--- a/toolbox/tree/tree_set_channelflag.m
+++ b/toolbox/tree/tree_set_channelflag.m
@@ -55,6 +55,10 @@ else
         error('Invalid call.');
     end
     % Get studies for files in input
+    sFiles = db_get('FunctionalFile', bstNodes, {'Id', 'Study'});
+    iStudies = [sFiles(:).Study];
+    iFiles   = [sFiles(:).Id];
+    
     sqlConn = sql_connect();
     for iFile = 1:length(DataFiles)
         sFile = sql_query(sqlConn, 'select', 'FunctionalFile', {'Id', 'Study'}, struct('FileName', DataFiles{iFile}));


### PR DESCRIPTION
With this modification in the `dbget('FunctionalFile')` case, we will be able to wrap the most common `sql_query('select')` from the FunctionalFile table. 
Calls for `sql_query('select')` from the FunctionalFile table have been replaced with `dbget('FunctionalFile')`.
A similar approach would be useful for `db_get()` cases for the rest of the SQLite tables.