### PR TITLE
Make consistent input and output args for db_get() and db_set()

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1186,12 +1186,13 @@ switch contextName
         else
             error('Invalid call to bst_get().');
         end
-        
+        sqlConn = sql_connect();
         % Look for specific surface file
-        sFile = db_get('SurfaceFile', SurfaceFile); 
-        argout1 = db_get('Subject', sFile.Subject);
+        sFile = db_get(sqlConn, 'SurfaceFile', SurfaceFile); 
+        argout1 = db_get(sqlConn, 'Subject', sFile.Subject);
         argout2 = sFile.Subject;
-        argout3 = sFile.Id;               
+        argout3 = sFile.Id;  
+        sql_close(sqlConn);
         
 %% ==== SURFACE FILE BY TYPE ====
     % Usage : [sSurface, iSurface] = bst_get('SurfaceFileByType', iSubject,    SurfaceType)

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -546,7 +546,7 @@ switch contextName
                 iDefaultSubject = iSubject;
             end
             % Get all anatomy files of each subject
-            sSubjects(iSubject) = db_get('FilesWithSubject', sqlConn, sSubjects(iSubject));
+            sSubjects(iSubject) = db_get(sqlConn, 'FilesWithSubject', sSubjects(iSubject));
         end
         
         % Separate default subject
@@ -571,7 +571,7 @@ switch contextName
         end
         
         sqlConn = sql_connect();
-        argout1.Study = db_get('Studies', sqlConn);
+        argout1.Study = db_get(sqlConn, 'Studies');
         defaultStudy = sql_query(sqlConn, 'select', 'study', '*', struct('Subject', 0, 'Name', '@default_study'));
         analysisStudy = sql_query(sqlConn, 'select', 'study', '*', struct('Name', '@inter'));
         
@@ -595,7 +595,7 @@ switch contextName
                 end
                 
                 % Populate functional files data
-                sStudy = db_get('FilesWithStudy', sqlConn, sStudy);
+                sStudy = db_get(sqlConn, 'FilesWithStudy', sStudy);
             end
             
             if iSub == -1
@@ -690,7 +690,7 @@ switch contextName
                 end
                 
                 % Populate functional files data
-                sStudy = db_get('FilesWithStudy', sqlConn, sStudy);
+                sStudy = db_get(sqlConn, 'FilesWithStudy', sStudy);
                 
                 argout1(iNext) = sStudy;
                 argout2(iNext) = sStudy.Id;
@@ -900,14 +900,14 @@ switch contextName
             % If subject uses default channel file    
             elseif (sSubject.UseDefaultChannel ~= 0)
                 % Get default study for this subject
-                iStudiesNew = db_get('DefaultStudy', sqlConn, iSubject);
+                iStudiesNew = db_get(sqlConn, 'DefaultStudy', iSubject);
                 iStudies = [iStudies, iStudiesNew];
             % Else: get all the studies belonging to this subject
             else
                 if NoIntra
-                    iStudiesNew = db_get('StudiesFromSubject', sqlConn, iSubject);
+                    iStudiesNew = db_get(sqlConn, 'StudiesFromSubject', iSubject);
                 else
-                    iStudiesNew = db_get('StudiesFromSubject', sqlConn, iSubject, 'intra_subject');
+                    iStudiesNew = db_get(sqlConn, 'StudiesFromSubject', iSubject, 'intra_subject');
                 end
                 iStudies = [iStudies, iStudiesNew];
             end
@@ -1164,7 +1164,7 @@ switch contextName
             end
             
             % Populate Surface & Anatomy files
-            sSubject = db_get('FilesWithSubject', sqlConn, sSubject);
+            sSubject = db_get(sqlConn, 'FilesWithSubject', sSubject);
             
             argout1 = sSubject;
             argout2 = iSubject;
@@ -1333,7 +1333,7 @@ switch contextName
         sStudy = sql_query(sqlConn, 'select', 'Study', 'Id', struct('FileName', StudyFile));
         % If data file instead on Study file
         if isempty(sStudy)
-            sFile = db_get('FunctionalFile', sqlConn, StudyFile, 'Study');
+            sFile = db_get(sqlConn, 'FunctionalFile', StudyFile, 'Study');
             if ~isempty(sFile)
                 iStudy = sFile.Study;
             end
@@ -1373,8 +1373,8 @@ switch contextName
         for i = 1:length(iStudies)           
             % Get study 
             iStudy = iStudies(i);
-            [iChannel, iChanStudy] = db_get('ChannelFromStudy', sqlConn, iStudy);
-            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
+            [iChannel, iChanStudy] = db_get(sqlConn, 'ChannelFromStudy', iStudy);
+            [~, sChannel] = db_get(sqlConn, 'FunctionalFile', iChannel);
             if ~isempty(sChannel)
                 iChanStudies = [iChanStudies, iChanStudy];
                 sListChannel = [sListChannel, sChannel];
@@ -1391,9 +1391,9 @@ switch contextName
     case 'ChannelModalities'
         % Get channel from input file
         sqlConn = sql_connect();
-        sFile = db_get('FunctionalFile', sqlConn, varargin{2}, {'Id', 'Study', 'Type'});
+        sFile = db_get(sqlConn, 'FunctionalFile', varargin{2}, {'Id', 'Study', 'Type'});
         if strcmpi(sFile.Type, 'channel')
-            [~, sChannel] = db_get('FunctionalFile', sqlConn, sFile.Id);
+            [~, sChannel] = db_get(sqlConn, 'FunctionalFile', sFile.Id);
             sql_close(sqlConn);
         else
             sql_close(sqlConn);

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -230,7 +230,7 @@ switch contextName
                 for iCat = 1:length(categories)
                     field = ['i' categories{iCat}];
                     if ~isempty(sStudy.(field)) && isnumeric(sStudy.(field))
-                        sFile = db_get('FunctionalFile', sqlConn, sStudy.(field), 'FileName');
+                        sFile = db_get(sqlConn, 'FunctionalFile', sStudy.(field), 'FileName');
                         if ~isempty(sFile)
                             sStudy.(field) = sFile.FileName;
                         end
@@ -390,7 +390,7 @@ switch contextName
                     selectedFiles{iCat} = sStudies(i).(field);
                 elseif ~isempty(sStudies(i).(field)) && isnumeric(sStudies(i).(field))
                     % Get FileName with previous file ID before it's deleted
-                    sFile = db_get('FunctionalFile', sqlConn, sStudies(i).(field), 'FileName');
+                    sFile = db_get(sqlConn, 'FunctionalFile', sStudies(i).(field), 'FileName');
                     if ~isempty(sFile)
                         selectedFiles{iCat} = sFile.FileName;
                     end

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -135,7 +135,7 @@ if isAnatomy
 else
     % Get parent file
     if ~isempty(ParentFile)
-        sParent = db_get('FunctionalFile', sqlConn, ParentFile, {'FileName', 'Type'});
+        sParent = db_get(sqlConn, 'FunctionalFile', ParentFile, {'FileName', 'Type'});
         if strcmpi(sParent.Type, 'folder')
             ParentFolder = sParent.FileName;
         else
@@ -162,17 +162,17 @@ if ismember(fileType, {'subjectimage', 'channel', 'noisecov', 'ndatacov'})
 %                 delfile = bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.Anatomy(1).FileName);
 %             end
         case 'channel'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'channel'), 'Filename');
+            sFile = db_get(sqlConn, 'FunctionalFile', struct('Study', iTarget, 'Type', 'channel'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile.FileName);
             end
         case 'noisecov'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'noisecov'), 'Filename');
+            sFile = db_get(sqlConn, 'FunctionalFile', struct('Study', iTarget, 'Type', 'noisecov'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end
         case 'ndatacov'
-            sFile = db_get('FunctionalFile', sqlConn, struct('Study', iTarget, 'Type', 'ndatacov'), 'Filename');
+            sFile = db_get(sqlConn, 'FunctionalFile', struct('Study', iTarget, 'Type', 'ndatacov'), 'Filename');
             if ~isempty(sFile)
                 delfile = bst_fullfile(ProtocolInfo.STUDIES, sFile(1).FileName);
             end

--- a/toolbox/db/db_add_data.m
+++ b/toolbox/db/db_add_data.m
@@ -86,7 +86,7 @@ if isempty(iItem)
         queryCond.ExtraStr1 = sNew.ExtraStr1;
     end
     
-    sFiles = db_get('FunctionalFile', sqlConn, queryCond, 'Name');
+    sFiles = db_get(sqlConn, 'FunctionalFile', queryCond, 'Name');
     if ~isempty(sFiles)
         Comment = file_unique(sNew.Name, {sFiles.Name});
         % Modify input file
@@ -100,7 +100,7 @@ if isempty(iItem)
     db_set(sqlConn, 'FunctionalFile', 'insert', sNew);
 else
     % Delete replaced file
-    sOld = db_get('FunctionalFile', sqlConn, iItem, 'FileName');
+    sOld = db_get(sqlConn, 'FunctionalFile', iItem, 'FileName');
     if ~isempty(sOld)
         file_delete(bst_fullfile(ProtocolInfo.STUDIES, sOld.FileName), 1);
     end

--- a/toolbox/db/db_add_subfolder.m
+++ b/toolbox/db/db_add_subfolder.m
@@ -72,7 +72,7 @@ for iStudy = iStudies
         sFile.ParentFile = iParent;
         
         % Get parent name
-        sParent = db_get('FunctionalFile', sqlConn, iParent, 'FileName');
+        sParent = db_get(sqlConn, 'FunctionalFile', iParent, 'FileName');
         sFile.FileName = bst_fullfile(sParent.FileName, FolderName);
     else
         % Get Subject & Study names

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -21,27 +21,24 @@ function varargout = db_get(varargin)
 % =============================================================================@
 %
 % Authors: Martin Cousineau, 2020
+%          Raymundo Cassani, 2021
 
 % Parse inputs
-contextName = varargin{1};
-if nargin < 2 || isempty(varargin{2}) || ~isjava(varargin{2})
-    sqlConn = sql_connect();
+if isjava(varargin{1}) && nargin > 1
+    handleConn = 0;
+    sqlConn = varargin{1};
+    varargin(1) = [];
+end
+if (nargin >= 1) && ischar(varargin{1}) 
+    args = {};
     handleConn = 1;
-    if nargin > 2 && isempty(varargin{2})
-        args = varargin(3:end);
-    elseif nargin > 1
+    sqlConn = sql_connect();
+    contextName = varargin{1};
+    if nargin > 1
         args = varargin(2:end);
-    else
-        args = {};
     end
 else
-    sqlConn = varargin{2};
-    handleConn = 0;
-    if nargin > 2
-        args = varargin(3:end);
-    else
-        args = {};
-    end
+    return
 end
 
 try
@@ -503,7 +500,7 @@ switch contextName
             if ~isempty(sStudy)
                 % If no channel selected, find first channel in study
                 if isempty(sStudy.iChannel)
-                    sFile = db_get('FunctionalFile', sqlConn, struct('Study', sStudy.Id, 'Type', 'channel'), 'Id');
+                    sFile = db_get(sqlConn, 'FunctionalFile', struct('Study', sStudy.Id, 'Type', 'channel'), 'Id');
                     if ~isempty(sFile)
                         sStudy.iChannel = sFile(1).Id;
                     end

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -38,7 +38,7 @@ if (nargin >= 1) && ischar(varargin{1})
         args = varargin(2:end);
     end
 else
-    return
+    error(['Usage : db_get(contextName) ' 10 '        db_get(sqlConn, contextName)']);
 end
 
 try

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -38,7 +38,7 @@ if (nargin >= 1) && ischar(varargin{1})
         args = varargin(2:end);
     end
 else
-    return
+    error(['Usage : db_set(contextName) ' 10 '        db_set(sqlConn, contextName)']);
 end
 
 try

--- a/toolbox/db/lock_acquire.m
+++ b/toolbox/db/lock_acquire.m
@@ -54,7 +54,7 @@ end
 % Get file ID
 if nargin > 3
     if ischar(FileId)
-        sFile = db_get('functionalfile', sqlConnection, FileId, 'Id');
+        sFile = db_get(sqlConnection, 'FunctionalFile', FileId, 'Id');
         FileId = sFile.Id;
     end
 else

--- a/toolbox/db/lock_read.m
+++ b/toolbox/db/lock_read.m
@@ -81,7 +81,7 @@ end
 if isempty(sLock) && ~isempty(FileId)
     ParentId = FileId;
     while 1
-        sParent = db_get('FunctionalFile', sqlConnection, ParentId, 'ParentFile');
+        sParent = db_get(sqlConnection, 'FunctionalFile', ParentId, 'ParentFile');
         if isempty(sParent) || isempty(sParent.ParentFile)
             break;
         end

--- a/toolbox/gui/panel_nodelist.m
+++ b/toolbox/gui/panel_nodelist.m
@@ -722,7 +722,7 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
         result.close();
         % Get channel file
         if iChannel ~= 0
-            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
+            [~, sChannel] = db_get(sqlConn, 'FunctionalFile', iChannel);
         else
             sChannel = [];
         end
@@ -747,19 +747,19 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
             % Data or results
             switch (ProcessType)
                 case 'data'
-                    [~, sData] = db_get('FunctionalFile', sqlConn, iItems(i));
+                    [~, sData] = db_get(sqlConn, 'FunctionalFile', iItems(i));
                     sFiles(i).FileName = file_win2unix(sData.FileName);
                     sFiles(i).Comment  = sData.Comment;
                     if strcmpi(sData.DataType, 'raw')
                         sFiles(i).FileType = 'raw';
                     end
                 case 'results'
-                    [~, sResult] = db_get('FunctionalFile', sqlConn, iItems(i));
+                    [~, sResult] = db_get(sqlConn, 'FunctionalFile', iItems(i));
                     sFiles(i).FileName = file_win2unix(sResult.FileName);
                     sFiles(i).Comment  = sResult.Comment;
                     sFiles(i).DataFile = file_win2unix(sResult.DataFile);
                 case 'timefreq'
-                    [~, sTimefreq] = db_get('FunctionalFile', sqlConn, iItems(i));
+                    [~, sTimefreq] = db_get(sqlConn, 'FunctionalFile', iItems(i));
                     % Do not accept TF/sources, because it's impossible to get the full matrix [nSources x nTime x nFrequencies]
                     if isFirstWarning && strcmpi(sTimefreq.DataType, 'results') && ~isempty(strfind(sTimefreq.FileName, '_KERNEL_'))
                         isFirstWarning = 0;
@@ -778,11 +778,11 @@ function sFiles = GetFiles(nodelistName)      %#ok<DEFNU>
                     sFiles(i).Comment  = sTimefreq.Comment;
                     sFiles(i).DataFile = file_win2unix(sTimefreq.DataFile);
                 case 'matrix'
-                    [~, sMatrix] = db_get('FunctionalFile', sqlConn, iItems(i));
+                    [~, sMatrix] = db_get(sqlConn, 'FunctionalFile', iItems(i));
                     sFiles(i).FileName = file_win2unix(sMatrix.FileName);
                     sFiles(i).Comment  = sMatrix.Comment;
                 case {'pdata','presults','ptimefreq','pmatrix'}
-                    [~, sStat] = db_get('FunctionalFile', sqlConn, iItems(i));
+                    [~, sStat] = db_get(sqlConn, 'FunctionalFile', iItems(i));
                     sFiles(i).FileName = file_win2unix(sStat.FileName);
                     sFiles(i).Comment  = sStat.Comment;
                 otherwise

--- a/toolbox/gui/panel_protocols.m
+++ b/toolbox/gui/panel_protocols.m
@@ -1209,8 +1209,8 @@ function destFile = CopyFile(iTarget, srcFile, srcType, iSrcStudy, sSubjectTarge
     % File info is not passed in input
     sqlConn = sql_connect();
     if nargin < 5 || isempty(sSubjectTargetRaw)
-        iSubjectTargetRaw = db_get('SubjectFromFunctionalFile', sqlConn, srcFile);
-        sSubjectTargetRaw = db_get('Subject', sqlConn, iSubjectTargetRaw);
+        iSubjectTargetRaw = db_get(sqlConn, 'SubjectFromFunctionalFile', srcFile);
+        sSubjectTargetRaw = db_get(sqlConn, 'Subject', iSubjectTargetRaw);
     end
     if nargin < 6
         ParentFile = [];
@@ -1218,7 +1218,7 @@ function destFile = CopyFile(iTarget, srcFile, srcType, iSrcStudy, sSubjectTarge
     isAnatomy = ismember(srcType, {'anatomy','cortex','scalp','innerskull','outerskull','fibers','fem','other'});
     % Get source subject
     if ~isAnatomy
-        iSubjectSrcRaw = db_get('SubjectFromStudy', sqlConn, iSrcStudy);
+        iSubjectSrcRaw = db_get(sqlConn, 'SubjectFromStudy', iSrcStudy);
         sSubjectSrcRaw = db_get('Subject', iSubjectSrcRaw);
         % Check if the subject changes
         UseDefaultAnatSrc    = (sSubjectSrcRaw.UseDefaultAnat == 1)    || (iSubjectSrcRaw == 0);

--- a/toolbox/gui/panel_protocols.m
+++ b/toolbox/gui/panel_protocols.m
@@ -1219,7 +1219,7 @@ function destFile = CopyFile(iTarget, srcFile, srcType, iSrcStudy, sSubjectTarge
     % Get source subject
     if ~isAnatomy
         iSubjectSrcRaw = db_get(sqlConn, 'SubjectFromStudy', iSrcStudy);
-        sSubjectSrcRaw = db_get('Subject', iSubjectSrcRaw);
+        sSubjectSrcRaw = db_get(sqlConn, 'Subject', iSubjectSrcRaw);
         % Check if the subject changes
         UseDefaultAnatSrc    = (sSubjectSrcRaw.UseDefaultAnat == 1)    || (iSubjectSrcRaw == 0);
         UseDefaultAnatTarget = (sSubjectTargetRaw.UseDefaultAnat == 1) || (iSubjectTargetRaw == 0);

--- a/toolbox/process/bst_process.m
+++ b/toolbox/process/bst_process.m
@@ -1586,7 +1586,7 @@ function sInputs = GetInputStruct(FileNames)
         [sInputs(iGroupFiles).SubjectFile] = deal(file_win2unix(SubjectFile));
         % Get channel file
         if iChannel ~= 0
-            [~, sChannel] = db_get('FunctionalFile', sqlConn, iChannel);
+            [~, sChannel] = db_get(sqlConn, 'FunctionalFile', iChannel);
             [sInputs(iGroupFiles).ChannelFile]  = deal(file_win2unix(sChannel.FileName));
             [sInputs(iGroupFiles).ChannelTypes] = deal(sChannel.Modalities);
         end
@@ -1597,7 +1597,7 @@ function sInputs = GetInputStruct(FileNames)
         % Get item info
         for iItem = 1:length(iGroupFiles)
             iInput = iGroupFiles(iItem);
-            [sFile, sItem] = db_get('FunctionalFile', sqlConn, GroupFileNames{iItem});
+            [sFile, sItem] = db_get(sqlConn, 'FunctionalFile', GroupFileNames{iItem});
             
             % Skip if file not found in database
             if isempty(sItem)

--- a/toolbox/process/panel_process_select.m
+++ b/toolbox/process/panel_process_select.m
@@ -85,7 +85,7 @@ function [bstPanel, panelName] = CreatePanel(sFiles, sFiles2, FileTimeVector)
     end
     % Get all the subjects names
     sqlConn = sql_connect();
-    sSubjects = db_get('Subjects', sqlConn);
+    sSubjects = db_get(sqlConn, 'Subjects');
     ProtocolInfo     = bst_get('ProtocolInfo');
     SubjectNames = {};
     iSelSubject = [];
@@ -93,7 +93,7 @@ function [bstPanel, panelName] = CreatePanel(sFiles, sFiles2, FileTimeVector)
         SubjectIds   = [sSubjects.Id];
         SubjectNames = {sSubjects.Name};
         if ~isempty(ProtocolInfo.iStudy)
-            iSelSubject = db_get('SubjectFromStudy', sqlConn, ProtocolInfo.iStudy);
+            iSelSubject = db_get(sqlConn, 'SubjectFromStudy', ProtocolInfo.iStudy);
         end
     end
     sql_close(sqlConn);

--- a/toolbox/tree/tree_set_channelflag.m
+++ b/toolbox/tree/tree_set_channelflag.m
@@ -117,7 +117,7 @@ for i = 1:length(iStudies)
     % Get data file
     iStudy = iStudies(i);
     iFile  = iFiles(i);
-    sFile = db_get('FunctionalFile', sqlConn, iFile, {'Type', 'FileName', 'Name', 'SubType'});
+    sFile = db_get(sqlConn, 'FunctionalFile', iFile, {'Type', 'FileName', 'Name', 'SubType'});
     if isempty(sFile)
         continue;
     end


### PR DESCRIPTION
- Update in the order and need of input arguments in `db_get()` and `db_set`
  The argument `sqlConn` is always the first,  and it can be omitted, no need of `[ ]`

-  `varargout` is now used on both functions

- All the calls to `db_get` and `db_set` have been updated and checked

   