### PR TITLE
Ftr restructure

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -591,7 +591,7 @@ switch contextName
             end
             
             if ~isempty(sStudy)
-                sSubject = sql_query(sqlConn, 'select', 'subject', 'FileName', struct('Id', sStudy.Subject));
+                sSubject = db_get(sqlConn, Subject, sStudy.Subject, 'FileName');
                 sStudy.BrainStormSubject = sSubject.FileName;
                 
                 if isempty(sStudy.Condition)
@@ -687,7 +687,7 @@ switch contextName
                     continue
                 end
                 
-                sSubject = sql_query(sqlConn, 'select', 'subject', 'FileName', struct('Id', sStudy.Subject));
+                sSubject = db_get(sqlConn, 'Subject', sStudy.Subject, 'FileName');
                 sStudy.BrainStormSubject = sSubject.FileName;
                 if isempty(sStudy.Condition)
                     sStudy.Condition = {sStudy.Name};
@@ -738,12 +738,11 @@ switch contextName
         
         sqlConn = sql_connect();
         % Get default subject
-        sDefaultSubject = sql_query(sqlConn, 'select', 'subject', 'FileName', ...
-            struct('Name', '@default_subject'));
+        sDefaultSubject = db_get(sqlConn, 'Subject', '@default_subject', 'FileName');
         % If SubjectFile is the default subject filename
         if ~isempty(sDefaultSubject) && ~isempty(sDefaultSubject.FileName) && file_compare(SubjectFile{1}, sDefaultSubject.FileName)
             % Get all the subjects files that use default anatomy
-            sSubject = sql_query(sqlConn, 'select', 'subject', 'FileName', struct('UseDefaultAnat', 1));
+            sSubject = db_get(sqlConn, 'Subject', struct('UseDefaultAnat', 1), 'FileName');
             if isempty(sSubject)
                 sql_close(sqlConn);
                 return
@@ -899,7 +898,7 @@ switch contextName
         sqlConn = sql_connect();
         for i=1:length(iSubjects)
             iSubject = iSubjects(i);
-            sSubject = sql_query(sqlConn, 'select', 'Subject', 'UseDefaultChannel', struct('Id', iSubject));
+            sSubject = db_get(sqlConn, 'Subject', iSubject, 'UseDefaultChannel');
             % No subject: error
             if isempty(sSubject) 
                 continue

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -541,12 +541,17 @@ switch contextName
         sSubjects = sql_query(sqlConn, 'select', 'subject', '*');
         iDefaultSubject = [];
         for iSubject = 1:length(sSubjects)
+            sSubject = sSubjects(iSubject);
             % Find default subject
-            if strcmp(sSubjects(iSubject).Name, '@default_subject')
+            if strcmp(sSubject.Name, '@default_subject')
                 iDefaultSubject = iSubject;
-            end
+            end           
             % Get all anatomy files of each subject
-            sSubjects(iSubject) = db_get(sqlConn, 'FilesWithSubject', sSubjects(iSubject));
+            sSubject.Anatomy = [repmat(db_template('Anatomy'), 0), ...
+                db_convert_anatomyfile(db_get(sqlConn, 'FilesWithSubject', sSubject.Id, 'anatomy'))]; 
+            sSubject.Surface = [repmat(db_template('Surface'), 0), ...
+                db_convert_anatomyfile(db_get(sqlConn, 'FilesWithSubject', sSubject.Id, 'surface'))]; 
+            sSubjects(iSubject) = sSubject;
         end
         
         % Separate default subject
@@ -1164,7 +1169,10 @@ switch contextName
             end
             
             % Populate Surface & Anatomy files
-            sSubject = db_get(sqlConn, 'FilesWithSubject', sSubject);
+            sSubject.Anatomy = [repmat(db_template('Anatomy'), 0), ...
+                db_convert_anatomyfile(db_get('FilesWithSubject', sSubject.Id, 'anatomy'))]; 
+            sSubject.Surface = [repmat(db_template('Surface'), 0), ...
+                db_convert_anatomyfile(db_get('FilesWithSubject', sSubject.Id, 'surface'))]; 
             
             argout1 = sSubject;
             argout2 = iSubject;
@@ -1188,10 +1196,10 @@ switch contextName
         end
         sqlConn = sql_connect();
         % Look for specific surface file
-        sFile = db_get(sqlConn, 'SurfaceFile', SurfaceFile); 
-        argout1 = db_get(sqlConn, 'Subject', sFile.Subject);
-        argout2 = sFile.Subject;
-        argout3 = sFile.Id;  
+        sAnatomyFile = db_get(sqlConn, 'AnatomyFile', SurfaceFile); 
+        argout1 = db_get(sqlConn, 'Subject', sAnatomyFile.Subject);
+        argout2 = sAnatomyFile.Subject;
+        argout3 = sAnatomyFile.Id;  
         sql_close(sqlConn);
         
 %% ==== SURFACE FILE BY TYPE ====
@@ -1298,7 +1306,7 @@ switch contextName
                 return
             end
         end
-        
+
         
 %% ==== CHANNEL FILE ====
     % Usage: [sStudy, iStudy, iChannel] = bst_get('ChannelFile', ChannelFile)

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -936,11 +936,7 @@ switch contextName
 %% ==== SUBJECTS COUNT ====
     % Usage: [nbSubjects] = bst_get('SubjectCount')
     case 'SubjectCount'
-        if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
-            argout1 = 0;
-            return;
-        end
-        argout1 = sql_query([], 'count', 'subject', [], 'WHERE Name <> "@default_subject"');
+        argout1 = db_get('SubjectCount');
         
 %% ==== NORMALIZED SUBJECT ====
     case 'NormalizedSubject'

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -538,7 +538,8 @@ switch contextName
         
         % Get all subjects
         sqlConn = sql_connect();
-        sSubjects = sql_query(sqlConn, 'select', 'subject', '*');
+        sSubjects = db_get(sqlConn, 'Subjects', 1);
+        
         iDefaultSubject = [];
         for iSubject = 1:length(sSubjects)
             sSubject = sSubjects(iSubject);
@@ -1061,10 +1062,7 @@ switch contextName
         if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
             return;
         end
-        sSubject = [];
         iSubject = [];
-        SubjectName = [];
-        SubjectFileName = [];
         % ISRAW parameter
         if (nargin < 3)
             isRaw = 0;
@@ -1077,104 +1075,55 @@ switch contextName
             iSubject = varargin{2};
             % If required subject is default subject (iSubject = 0)
             if (iSubject == 0)
-                sSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('Name', '@default_subject'));
+                sSubject = db_get(sqlConn, 'Subject', '@default_subject');
             % Normal subject 
             else
-                sSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('Id', iSubject));
+                sSubject = db_get(sqlConn, 'Subject', iSubject, '*', isRaw);
             end
-            % Subject not found
-            if isempty(sSubject)
-                sql_close(sqlConn);
-                argout1 = sSubject;
-                argout2 = iSubject;
-                return
-            end
-            
+
+        % Call: bst_get('subject', []);            
+        elseif (nargin >= 2) && isempty(varargin{2})
+            % If second argument is empty: use DefaultSubject
+            sSubject = db_get(sqlConn, 'Subject', '@default_subject');           
+
         % Call: bst_get('subject', SubjectFileName, isRaw);
         % Call: bst_get('subject', SubjectName,     isRaw);
-        elseif (nargin >= 2) && isempty(varargin{2})
-            % If study name is empty: use DefaultSubject
-            SubjectName = '@default_subject';
         elseif (nargin >= 2) && (ischar(varargin{2}))
-            [fName, fBase, fExt] = bst_fileparts(varargin{2});
+            [~, ~, fExt] = bst_fileparts(varargin{2});
             % Argument is a Matlab .mat filename
             if strcmpi(fExt, '.mat')
                 SubjectFileName = varargin{2};
             % Else : assume argument is a directory
             else
-                SubjectName = file_standardize(varargin{2});
+                SubjectFileName = bst_fullfile(file_standardize(varargin{2}), 'brainstormsubject.mat');
             end
+            sSubject = db_get(sqlConn, 'Subject', SubjectFileName, '*', isRaw);
                             
         % Call: bst_get('subject');   => looking for current subject 
         elseif (nargin < 2)
             % Get currently selected subject
-            ProtocolInfo = bst_get('ProtocolInfo');
-            if ~isempty(ProtocolInfo.iSubject)
-                iSubject = ProtocolInfo.iSubject;
-                sSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('Id', iSubject));
-            end
-            
-            if isempty(ProtocolInfo.iSubject) || isempty(sSubject)
-                sql_close(sqlConn);
-                argout1 = [];
-                argout2 = [];
-                return;
-            end
+            sSubject = db_get(sqlConn, 'Subject');          
         else
+            sql_close(sqlConn);
             error('Invalid call to bst_get()');
         end
-
+        
         % If Subject is defined by its filename/name
         if isempty(sSubject)
-            if ~isempty(SubjectFileName)
-                sSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('FileName', SubjectFileName));
-            elseif ~isempty(SubjectName)
-                sSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('Name', SubjectName));
-            else
-                error('Subject name not specified.');
-            end
-            
-            if ~isempty(sSubject)
-                if strcmpi(sSubject.Name, '@default_subject')
-                    iSubject = 0;
-                else
-                    iSubject = sSubject.Id;
-                end
-            end
-        end
-        
-        % Return found subject
-        if ~isempty(iSubject) && ~isempty(sSubject)
-            % If subject uses default subject
-            useDefaultSubject = sSubject.UseDefaultAnat && ~isRaw && iSubject ~= 0;
-            if useDefaultSubject
-                sDefaultSubject = sql_query(sqlConn, 'select', 'subject', '*', ...
-                    struct('Name', '@default_subject'));
-            end
-            if useDefaultSubject && ~isempty(sDefaultSubject)
-                % Return default subject (WITH REAL SUBJECT'S NAME)
-                sDefaultSubject.Name              = sSubject.Name;
-                sDefaultSubject.UseDefaultAnat    = sSubject.UseDefaultAnat;
-                sDefaultSubject.UseDefaultChannel = sSubject.UseDefaultChannel;
-                sSubject = sDefaultSubject;
-            end
-            
-            % Populate Surface & Anatomy files
-            sSubject.Anatomy = [repmat(db_template('Anatomy'), 0), ...
-                db_convert_anatomyfile(db_get('FilesWithSubject', sSubject.Id, 'anatomy'))]; 
-            sSubject.Surface = [repmat(db_template('Surface'), 0), ...
-                db_convert_anatomyfile(db_get('FilesWithSubject', sSubject.Id, 'surface'))]; 
-            
             argout1 = sSubject;
             argout2 = iSubject;
+        % Return found subject
+        else                 
+            % Populate Surface & Anatomy files
+            sSubject.Anatomy = [repmat(db_template('Anatomy'), 0), ...
+                db_convert_anatomyfile(db_get(sqlConn, 'FilesWithSubject', sSubject.Id, 'anatomy'))]; 
+            sSubject.Surface = [repmat(db_template('Surface'), 0), ...
+                db_convert_anatomyfile(db_get(sqlConn, 'FilesWithSubject', sSubject.Id, 'surface'))]; 
+            
+            argout1 = sSubject;
+            argout2 = sSubject.Id;
         end
-        sql_close(sqlConn);
-
+        sql_close(sqlConn);        
         
 %% ==== SURFACE FILE ====
     % Usage : [sSubject, iSubject, iSurface] = bst_get('SurfaceFile', SurfaceFile)

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -243,7 +243,7 @@ switch contextName
             end
             
             % Get ID of parent subject
-            sSubject = sql_query(sqlConn, 'select', 'subject', 'Id', struct('FileName', sStudy.BrainStormSubject));
+            sSubject = db_get(sqlConn, 'Subject', sStudy.BrainStormSubject, 'Id');
             sStudy.Id = [];
             sStudy.Subject = sSubject.Id;
             sStudy.Condition = char(sStudy.Condition);
@@ -298,9 +298,9 @@ switch contextName
         
         % If default subject
         if (iSubject == 0)
-            sExistingSubject = sql_query(sqlConn, 'select', 'subject', 'Id', struct('Name', '@default_subject'));
+            sExistingSubject = db_get(sqlConn, 'Subject', '@default_subject', 'Id');
         else
-            sExistingSubject = sql_query(sqlConn, 'select', 'subject', 'Id', struct('Id', iSubject));
+            sExistingSubject = db_get(sqlConn, 'Subject', iSubject, 'Id');
         end
         
         % Extract selected anat/surf files to get inserted ID later
@@ -380,7 +380,7 @@ switch contextName
             end
             
             % Get ID of parent subject
-            sSubject = sql_query(sqlConn, 'select', 'subject', 'Id', struct('FileName', sStudies(i).BrainStormSubject));
+            sSubject = db_get(sqlConn, 'Subject', sStudies(i).BrainStormSubject, 'Id');
             sStudies(i).Subject = sSubject.Id;
             
             % Extract selected channel/head model to get inserted ID later

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -148,7 +148,7 @@ switch contextName
         sqlConn = sql_connect();
         
         % Delete existing subjects and anatomy files
-        sql_query(sqlConn, 'delete', 'subject');
+        db_set(sqlConn, 'Subject', 'delete');
         db_set(sqlConn, 'AnatomyFile', 'delete');
         
         for iSubject = 0:length(contextValue.Subject)
@@ -180,7 +180,7 @@ switch contextName
             end
             
             % Insert subject
-            SubjectId = sql_query(sqlConn, 'insert', 'subject', sSubject);
+            SubjectId = db_set(sqlConn, 'Subject', sSubject);
             
             % Convert Anatomy & Surface files to AnatomyFiles and insert
             sAnatomyFiles = [db_convert_anatomyfile(sSubject.Anatomy, 'anatomy'), ...
@@ -197,7 +197,7 @@ switch contextName
                 end
             end
             if hasSelFiles
-                sql_query(sqlConn, 'update', 'subject', selFiles, struct('Id', SubjectId));
+                db_set(sqlConn, 'Subject', selFiles, SubjectId);
             end
         end
         
@@ -319,13 +319,10 @@ switch contextName
         % If subject exists, UPDATE query
         if ~isempty(sExistingSubject)
             sSubject.Id = sExistingSubject.Id;
-            result = sql_query(sqlConn, 'update', 'subject', sSubject, struct('Id', sExistingSubject.Id));
-            if result
-                argout1 = sExistingSubject.Id;
-            end
+            sExistingSubject.Id = db_set(sqlConn, 'Subject', sSubject, sExistingSubject.Id);
         else
             sSubject.Id = [];
-            iSubject = sql_query(sqlConn, 'insert', 'subject', sSubject);
+            iSubject = db_set(sqlConn, 'Subject', sSubject);
             if ~isempty(iSubject)
                 argout1 = iSubject;
             end
@@ -351,7 +348,7 @@ switch contextName
                 end
             end
             if hasSelFiles
-                sql_query(sqlConn, 'update', 'subject', selFiles, struct('Id', argout1));
+                db_set(sqlConn, 'Subject', selFiles, argout1);
             end
             
         end

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -128,7 +128,7 @@ ProtocolInfo = bst_get('ProtocolInfo');
 sqlConn = sql_connect();
 if isAnatomy
     % Get destination study
-    sSubject = sql_query(sqlConn, 'select', 'Subject', 'FileName', struct('Id', iTarget));
+    sSubject = db_get(sqlConn, 'Subject', iTarget, 'FileName');
     % Build full filename
     OutputFileFull = file_unique(bst_fullfile(ProtocolInfo.SUBJECTS, bst_fileparts(sSubject.FileName), OutputFile));
     OutputFile = file_short(OutputFileFull);

--- a/toolbox/db/db_add.m
+++ b/toolbox/db/db_add.m
@@ -199,8 +199,8 @@ if isAnatomy
         case 'subjectimage'
             % Nothing to do: file is replaced anyway
         case {'tess', 'cortex', 'scalp', 'outerskull', 'innerskull', 'fibers', 'fem'}
-            sFiles = sql_query(sqlConn, 'select', 'AnatomyFile', 'Name', struct('Subject', iTarget));
-            sMat.Comment = file_unique(sMat.Comment, {sFiles.Name});
+            sAnatomyFiles = db_get(sqlConn, 'AnatomyFile', struct('Subject', 0), 'Name');
+            sMat.Comment = file_unique(sMat.Comment, {sAnatomyFiles.Name});
     end
 else
     % Add comment if missing
@@ -252,7 +252,7 @@ if isAnatomy
     sFile.FileName = OutputFile;
     sFile.Name = sMat.Comment;
     %TODO: sFile.SurfaceType
-    sql_query(sqlConn, 'insert', 'AnatomyFile', sFile);
+    db_set(sqlConn, 'AnatomyFile', sFile);
 else
     sFile = db_template('FunctionalFile');
     sFile.Study = iTarget;

--- a/toolbox/db/db_add_condition.m
+++ b/toolbox/db/db_add_condition.m
@@ -84,7 +84,7 @@ end
 sqlConn = sql_connect();
 for iSubject = iSubjectsList
     % Get subject definition
-    sSubject = db_get(sqlConn, 'Subject', iSubject, 'FileName');
+    sSubject = db_get(sqlConn, 'Subject', iSubject, {'FileName', 'Name'});
     SubjectFile = sSubject.FileName;
     SubjectName = sSubject.Name;
     % Get conditions for this subject

--- a/toolbox/db/db_add_condition.m
+++ b/toolbox/db/db_add_condition.m
@@ -84,7 +84,7 @@ end
 sqlConn = sql_connect();
 for iSubject = iSubjectsList
     % Get subject definition
-    sSubject = sql_query(sqlConn, 'select', 'Subject', {'Name', 'FileName'}, struct('Id', iSubject));
+    sSubject = db_get(sqlConn, 'Subject', iSubject, 'FileName');
     SubjectFile = sSubject.FileName;
     SubjectName = sSubject.Name;
     % Get conditions for this subject

--- a/toolbox/db/db_add_subject.m
+++ b/toolbox/db/db_add_subject.m
@@ -78,7 +78,7 @@ if sql_row_exists(sqlConn, 'Subject', struct('Name', sSubject.Name))
 end
 
 % Add subject to database
-sql_query(sqlConn, 'insert', 'subject', sSubject);
+db_set(sqlConn, 'Subject', sSubject);
 sql_close(sqlConn);
 
 %% ===== SAVE SUBJECT FILE =====

--- a/toolbox/db/db_convert_anatomyfile.m
+++ b/toolbox/db/db_convert_anatomyfile.m
@@ -7,6 +7,26 @@ function outStructs = db_convert_anatomyfile(inStructs, type)
 % Old to New
 % sAnatomyFile = db_convert_anatomyfile(sAnatomy, 'anatomy')
 % sAnatomyFile = db_convert_anatomyfile(sSurface, 'surface')
+%
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2020 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Raymundo Cassani, 2021
 
 % Validate 'type' argument
 if ~exist('type','var') || isempty(type)

--- a/toolbox/db/db_convert_anatomyfile.m
+++ b/toolbox/db/db_convert_anatomyfile.m
@@ -1,0 +1,55 @@
+function outStructs = db_convert_anatomyfile(inStructs, type)
+% Bidirectional conversion between Old and New structures
+%
+% New to Old
+% sAnatomy / sSurface = db_convert_anatomyfile(sAnatomyFile)
+% 
+% Old to New
+% sAnatomyFile = db_convert_anatomyfile(sAnatomy, 'anatomy')
+% sAnatomyFile = db_convert_anatomyfile(sSurface, 'surface')
+
+% Validate 'type' argument
+if ~exist('type','var') || isempty(type)
+    type = '';
+end
+
+nStructs = length(inStructs);
+
+if nStructs < 1
+    outStructs = [];
+    return
+end 
+
+% Verify the sense of the conversion
+% New to old
+if all(isfield(inStructs(1), {'Id', 'Type'})) 
+    outStructs = repmat(db_template(inStructs(1).Type), 1, nStructs);
+    for iStruct = 1 : nStructs 
+        % Common fields
+        outStructs(iStruct).FileName = inStructs(iStruct).FileName;
+        outStructs(iStruct).Comment  = inStructs(iStruct).Name;
+        % Extra fields
+        if strcmpi(inStructs(iStruct).Type, 'surface')
+            outStructs(iStruct).SurfaceType = inStructs(iStruct).SurfaceType;    
+        end
+    end
+    
+% Old to new    
+else 
+    outStructs = repmat(db_template('AnatomyFile'), 1, nStructs);
+    for iStruct = 1 : nStructs
+        % Common fields
+        outStructs(iStruct).FileName = inStructs(iStruct).FileName;
+        outStructs(iStruct).Name     = inStructs(iStruct).Comment;
+        outStructs(iStruct).Type     = type;
+        % Extra fileds
+        switch lower(type)
+            case 'anatomy'
+            % No extra fields
+            case 'surface'
+            outStructs(iStruct).SurfaceType = inStructs(iStruct).SurfaceType;
+            otherwise
+            error('Unsupported input structure type');
+        end
+    end
+end

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -67,26 +67,25 @@ function varargout = db_get(varargin)
 %          Raymundo Cassani, 2021
 
 %% ==== PARSE INPUTS ====
-if isjava(varargin{1}) && nargin > 1
-    handleConn = 0;
+if (nargin > 1) && isjava(varargin{1})
     sqlConn = varargin{1};
     varargin(1) = [];
-end
-if (nargin >= 1) && ischar(varargin{1}) 
-    args = {};
-    handleConn = 1;
+    handleConn = 0;
+elseif (nargin >= 1) && ischar(varargin{1}) 
     sqlConn = sql_connect();
-    contextName = varargin{1};
-    if nargin > 1
-        args = varargin(2:end);
-    end
+    handleConn = 1;
 else
     error(['Usage : db_get(contextName) ' 10 '        db_get(sqlConn, contextName)']);
 end
 
 try
+contextName = varargin{1};
+args = {};
+if length(varargin) > 1
+    args = varargin(2:end);
+end
 varargout = {};
-
+    
 % Get required context structure
 switch contextName
 %% ==== SUBJECT ====

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -339,24 +339,31 @@ switch contextName
         iFiles = args{1};
         fields = '*';                              
         templateStruct = db_template('AnatomyFile');
-
+        resultStruct = templateStruct; 
+        
         if ischar(iFiles)
             iFiles = {iFiles};
         elseif isstruct(iFiles)
             condQuery = args{1};           
         end
 
+        % Parse Fields parameter
         if length(args) > 1
             fields = args{2};
-            if ischar(fields)
+            % Set fields for resultStruct
+            if ischar(fields) && ~strcmp(fields, '*')
                 fields = {fields};
-            end
-            for i = 1 : length(fields)
-                resultStruct.(fields{i}) = templateStruct.(fields{i});
-            end
-        else
-            resultStruct = templateStruct;
-        end
+                % Verify requested fields
+                if ~all(isfield(templateStruct, fields))
+                    error('Invalid Fields requested in db_get()');
+                else
+                    resultStruct = [];
+                    for i = 1 : length(fields)
+                        resultStruct.(fields{i}) = templateStruct.(fields{i});
+                    end
+                end
+            end           
+        end        
 
         % Input is FileIDs and FileNames
         if ~isstruct(iFiles)

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -488,8 +488,7 @@ switch contextName
             % === All other nodes ===
             else
                 % Get subject attached to study
-                sSubject = sql_query(sqlConn, 'select', 'Subject', 'UseDefaultChannel', ...
-                    struct('Id', sStudy.Subject));
+                sSubject = db_get(sqlConn, 'Subject', sStudy.Subject, 'UseDefaultChannel');
                 % Subject uses default channel/headmodel
                 if ~isempty(sSubject) && (sSubject.UseDefaultChannel ~= 0)
                     sStudy = sql_query(sqlConn, 'select', 'Study', {'Id', 'iChannel'}, ...
@@ -564,7 +563,7 @@ switch contextName
             % Return Global default study
         % === NORMAL SUBJECT ===
         else
-            sSubject = sql_query(sqlConn, 'select', 'Subject', 'UseDefaultChannel', struct('Id', iSubject));
+            sSubject = db_get(sqlConn, 'Subject', iSubject, 'UseDefaultChannel');
             % === GLOBAL DEFAULT STUDY ===
             if sSubject.UseDefaultChannel == 2
                 % Return Global default study

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -119,13 +119,14 @@ switch contextName
         elseif isstruct(iSubjects)
             condQuery = args{1};           
         end
-
+        
         % Parse Fields parameter
         if length(args) > 1
             fields = args{2};
-            % Set fields for resultStruct
-            if ischar(fields) && ~strcmp(fields, '*')
-                fields = {fields};
+            if ~strcmp(fields, '*')
+                if ischar(fields)
+                    fields = {fields};
+                end
                 % Verify requested fields
                 if ~all(isfield(templateStruct, fields))
                     error('Invalid Fields requested in db_get()');
@@ -135,9 +136,9 @@ switch contextName
                         resultStruct.(fields{i}) = templateStruct.(fields{i});
                     end
                 end
-            end           
-        end
-                       
+            end
+        end            
+        
         % isRaw parameter
         if length(args) > 2
             isRaw = args{3};
@@ -185,7 +186,6 @@ switch contextName
                         tmp.Name              = sSubjects(i).Name;
                         tmp.UseDefaultAnat    = sSubjects(i).UseDefaultAnat;
                         tmp.UseDefaultChannel = sSubjects(i).UseDefaultChannel;
-                        tmp.UseDefaultChannel = sSubjects(i).UseDefaultChannel;
                         sSubjects(i) = tmp;                   
                     end    
                 end
@@ -210,10 +210,6 @@ switch contextName
 %% ==== SUBJECTS COUNT ====
     % nSubjects = db_get('SubjectCount')
     case 'SubjectCount'
-        if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
-            varargout{1} = 0;
-            return;
-        end
         varargout{1} = sql_query(sqlConn, 'count', 'subject', [], 'WHERE Name <> "@default_subject"');
         
 %% ==== FILES WITH SUBJECT ====
@@ -355,9 +351,10 @@ switch contextName
         % Parse Fields parameter
         if length(args) > 1
             fields = args{2};
-            % Set fields for resultStruct
-            if ischar(fields) && ~strcmp(fields, '*')
-                fields = {fields};
+            if ~strcmp(fields, '*')
+                if ischar(fields)
+                    fields = {fields};
+                end
                 % Verify requested fields
                 if ~all(isfield(templateStruct, fields))
                     error('Invalid Fields requested in db_get()');
@@ -367,8 +364,8 @@ switch contextName
                         resultStruct.(fields{i}) = templateStruct.(fields{i});
                     end
                 end
-            end           
-        end        
+            end
+        end         
 
         % Input is FileIDs and FileNames
         if ~isstruct(iFiles)

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -217,13 +217,18 @@ switch contextName
         varargout{1} = sql_query(sqlConn, 'count', 'subject', [], 'WHERE Name <> "@default_subject"');
         
 %% ==== FILES WITH SUBJECT ====
-    % sAnatomyFiles = db_get('FilesWithSubject', SubjectID, AnatomyFileType)
+    % sAnatomyFiles = db_get('FilesWithSubject', SubjectID, AnatomyFileType, Fields)
     case 'FilesWithSubject'
         condQuery.Subject = args{1};
         if length(args) > 1 
             condQuery.Type = lower(args{2});
+            if length(args) > 2
+                fields = args{3};
+            else
+                fields = '*';
+            end
         end
-        varargout{1} = db_get(sqlConn, 'AnatomyFile', condQuery);
+        varargout{1} = db_get(sqlConn, 'AnatomyFile', condQuery, fields);
 
 
 %% ==== FILES WITH STUDY ====

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -64,6 +64,7 @@ function varargout = db_get(varargin)
 %          Raymundo Cassani, 2021
 
 %% ==== PARSE INPUTS ====
+global GlobalData;
 if (nargin > 1) && isjava(varargin{1})
     sqlConn = varargin{1};
     varargin(1) = [];
@@ -206,6 +207,15 @@ switch contextName
         end
         varargout{1} = sql_query(sqlConn, 'select', 'subject', '*', [], addQuery);
 
+%% ==== SUBJECTS COUNT ====
+    % nSubjects = db_get('SubjectCount')
+    case 'SubjectCount'
+        if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
+            varargout{1} = 0;
+            return;
+        end
+        varargout{1} = sql_query(sqlConn, 'count', 'subject', [], 'WHERE Name <> "@default_subject"');
+        
 %% ==== FILES WITH SUBJECT ====
     % sAnatomyFiles = db_get('FilesWithSubject', SubjectID, AnatomyFileType)
     case 'FilesWithSubject'

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -70,12 +70,14 @@ varargout = {};
 % Set required context structure
 switch contextName
 %% ==== SUBJECT ====
-    % [Sucess]               db_set('Subject', 'Delete')
-    % [Sucess]               db_set('Subject', 'Delete', SubjectId)
-    % [Sucess]               db_set('Subject', 'Delete', CondQuery)
+    % [Success]              db_set('Subject', 'Delete')
+    % [Success]              db_set('Subject', 'Delete', SubjectId)
+    % [Success]              db_set('Subject', 'Delete', CondQuery)
     % [SubjectId, Subject] = db_set('Subject', Subject)
     % [SubjectId, Subject] = db_set('Subject', Subject, SubjectId)
     case 'Subject'
+        % Default parameters
+        iSubject = [];       
         varargout{1} = [];
         
         if length(args) < 1
@@ -88,7 +90,7 @@ switch contextName
         end
         % Delete 
         if ischar(sSubject) && strcmpi(sSubject, 'delete')
-            if ~exist('iSubject','var')
+            if isempty(iSubject)
                 % Delete all rows in Subject table
                 delResult = sql_query(sqlConn, 'delete', 'subject');
             else
@@ -106,7 +108,7 @@ switch contextName
             
         % Insert or Update    
         elseif isstruct(sSubject)
-            if ~exist('iSubject','var')
+            if isempty(iSubject)
                 % Insert Subject row
                 sSubject.Id = []; 
                 iSubject = sql_query(sqlConn, 'insert', 'subject', sSubject);
@@ -115,6 +117,8 @@ switch contextName
                 % Update Subject row
                 if ~isfield(sSubject, 'Id') || isempty(sSubject.Id) || sSubject.Id == iSubject
                     resUpdate = sql_query(sqlConn, 'update', 'subject', sSubject, struct('Id', iSubject));
+                else
+                    error('Cannot update Subject, Ids do not match');
                 end
                 if resUpdate>0
                     varargout{1} = iSubject;
@@ -130,12 +134,14 @@ switch contextName
 
         
 %% ==== ANATOMY FILES ====
-    % [Sucess]                       db_set('AnatomyFile', 'Delete')
-    % [Sucess]                       db_set('AnatomyFile', 'Delete', AnatomyFileId)
-    % [Sucess]                       db_set('AnatomyFile', 'Delete', CondQuery)
+    % [Success]                      db_set('AnatomyFile', 'Delete')
+    % [Success]                      db_set('AnatomyFile', 'Delete', AnatomyFileId)
+    % [Success]                      db_set('AnatomyFile', 'Delete', CondQuery)
     % [AnatomyFileId, AnatomyFile] = db_set('AnatomyFile', AnatomyFile)
     % [AnatomyFileId, AnatomyFile] = db_set('AnatomyFile', AnatomyFile, AnatomyFileId)
     case 'AnatomyFile'
+        % Default parameters
+        iAnatomyFile = [];       
         varargout{1} = [];
         
         if length(args) < 1
@@ -148,7 +154,7 @@ switch contextName
         end
         % Delete 
         if ischar(sAnatomyFile) && strcmpi(sAnatomyFile, 'delete')
-            if ~exist('iAnatomyFile','var')
+            if isempty(iAnatomyFile)
                 % Delete all rows in AnatomyFile table
                 delResult = sql_query(sqlConn, 'delete', 'anatomyfile');
             else
@@ -166,7 +172,7 @@ switch contextName
             
         % Insert or Update    
         elseif isstruct(sAnatomyFile)
-            if ~exist('iAnatomyFile','var')
+            if isempty(iAnatomyFile)
                 % Insert AnatomyFile row
                 sAnatomyFile.Id = []; 
                 iAnatomyFile = sql_query(sqlConn, 'insert', 'anatomyfile', sAnatomyFile);
@@ -175,6 +181,8 @@ switch contextName
                 % Update iAnatomyFile row
                 if ~isfield(sAnatomyFile, 'Id') || isempty(sAnatomyFile.Id) || sAnatomyFile.Id == iAnatomyFile
                     resUpdate = sql_query(sqlConn, 'update', 'anatomyfile', sAnatomyFile, struct('Id', iAnatomyFile));
+                else
+                    error('Cannot update AnatomyFile, Ids do not match');
                 end
                 if resUpdate>0
                     varargout{1} = iAnatomyFile;

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -48,24 +48,23 @@ function varargout = db_set(varargin)
 %          Raymundo Cassani, 2021
 
 %% ==== PARSE INPUTS ====
-if isjava(varargin{1}) && nargin > 1
-    handleConn = 0;         
-    sqlConn = varargin{1};  
+if (nargin > 1) && isjava(varargin{1})
+    sqlConn = varargin{1};
     varargin(1) = [];
-end
-if (nargin >= 1) && ischar(varargin{1}) 
-    args = {};
-    handleConn = 1;
+    handleConn = 0;
+elseif (nargin >= 1) && ischar(varargin{1}) 
     sqlConn = sql_connect();
-    contextName = varargin{1};
-    if nargin > 1
-        args = varargin(2:end);
-    end
+    handleConn = 1;
 else
     error(['Usage : db_set(contextName) ' 10 '        db_set(sqlConn, contextName)']);
 end
 
 try
+contextName = varargin{1};
+args = {};
+if length(varargin) > 1
+    args = varargin(2:end);
+end
 varargout = {};
    
 % Set required context structure

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -69,6 +69,66 @@ varargout = {};
    
 % Set required context structure
 switch contextName
+%% ==== SUBJECT ====
+    % [Sucess]               db_set('Subject', 'Delete')
+    % [Sucess]               db_set('Subject', 'Delete', SubjectId)
+    % [Sucess]               db_set('Subject', 'Delete', CondQuery)
+    % [SubjectId, Subject] = db_set('Subject', Subject)
+    % [SubjectId, Subject] = db_set('Subject', Subject, SubjectId)
+    case 'Subject'
+        varargout{1} = [];
+        
+        if length(args) < 1
+            error('Error in number of arguments')
+        end
+        
+        sSubject = args{1};
+        if length(args) > 1
+            iSubject = args{2};
+        end
+        % Delete 
+        if ischar(sSubject) && strcmpi(sSubject, 'delete')
+            if ~exist('iSubject','var')
+                % Delete all rows in Subject table
+                delResult = sql_query(sqlConn, 'delete', 'subject');
+            else
+                if isstruct(iSubject)
+                    % Delete using the CondQuery
+                    delResult = sql_query(sqlConn, 'delete', 'subject', iSubject);                    
+                elseif isnumeric(iSubject)
+                    % Delete using iSubject
+                    delResult = sql_query(sqlConn, 'delete', 'subject', struct('Id', iSubject));  
+                end
+            end
+            if delResult > 0
+                varargout{1} = 1;
+            end
+            
+        % Insert or Update    
+        elseif isstruct(sSubject)
+            if ~exist('iSubject','var')
+                % Insert Subject row
+                sSubject.Id = []; 
+                iSubject = sql_query(sqlConn, 'insert', 'subject', sSubject);
+                varargout{1} = iSubject;
+            else
+                % Update Subject row
+                if ~isfield(sSubject, 'Id') || isempty(sSubject.Id) || sSubject.Id == iSubject
+                    resUpdate = sql_query(sqlConn, 'update', 'subject', sSubject, struct('Id', iSubject));
+                end
+                if resUpdate>0
+                    varargout{1} = iSubject;
+                end
+            end
+            % If requested, get the inserted or updated row
+            if nargout > 1
+                varargout{2} = db_get(sqlConn, 'subject', iSubject);
+            end
+        else
+            % No action
+        end        
+
+        
 %% ==== ANATOMY FILES ====
     % [Sucess]                       db_set('AnatomyFile', 'Delete')
     % [Sucess]                       db_set('AnatomyFile', 'Delete', AnatomyFileId)

--- a/toolbox/db/db_surface_default.m
+++ b/toolbox/db/db_surface_default.m
@@ -85,7 +85,10 @@ DefaultFile = file_win2unix(DefaultFile);
 % Save in database selected file
 sSubject.(['i' SurfaceType]) = iSurface;
 db_set(sqlConn, 'Subject', sSubject, iSubject);
+% Unlock Subject
+lock_release(sqlConn, LockId);
 sql_close(sqlConn);
+
 % Update SubjectFile
 matUpdate.(SurfaceType) = DefaultFile;
 bst_save(bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.FileName), matUpdate, 'v7', 1);
@@ -105,6 +108,5 @@ if isUpdate
     end
 end
 
-% Unlock Subject
-lock_release([], LockId);
+
 

--- a/toolbox/db/db_surface_default.m
+++ b/toolbox/db/db_surface_default.m
@@ -23,9 +23,13 @@ function sSubject = db_surface_default( iSubject, SurfaceType, iSurface, isUpdat
 %
 % Authors: Francois Tadel, 2008-2011
 
+% Lock Subject
+LockId = lock_acquire(mfilename, iSubject);
+
 % Get protocol description
 ProtocolInfo = bst_get('ProtocolInfo');
-sSubject = bst_get('Subject', iSubject);
+sqlConn = sql_connect();
+sSubject = db_get(sqlConn, 'Subject', iSubject);
 
 % ===== GET DEFAULT SURFACE =====
 % By default: update tree
@@ -43,7 +47,7 @@ if (nargin < 3) || isempty(iSurface)
     else
         defSurfFile = [];
     end
-        
+
     % == ANATOMY ==
     if strcmpi(SurfaceType, 'Anatomy')
         % Try to find the default surface file
@@ -69,15 +73,8 @@ end
 
 % Get new default surface
 if ~isempty(iSurface)
-    if strcmpi(SurfaceType, 'Anatomy')
-        sSurface = sSubject.Anatomy(iSurface);
-    else
-        if (iSurface > length(sSubject.Surface))
-            error(sprintf('Invalid surface index #%d. Subject has only %d registered surfaces.', iSurface, length(sSubject.Surface)));
-        end
-        sSurface = sSubject.Surface(iSurface);
-    end
-    DefaultFile = sSurface.FileName;
+    sAnatomyFile = db_get(sqlConn, 'AnatomyFile', iSurface);
+    DefaultFile = sAnatomyFile.FileName;    
 else
     DefaultFile = '';
 end
@@ -87,7 +84,8 @@ DefaultFile = file_win2unix(DefaultFile);
 % ===== UPDATE DATABASE =====
 % Save in database selected file
 sSubject.(['i' SurfaceType]) = iSurface;
-bst_set('Subject', iSubject, sSubject);
+db_set(sqlConn, 'Subject', sSubject, iSubject);
+sql_close(sqlConn);
 % Update SubjectFile
 matUpdate.(SurfaceType) = DefaultFile;
 bst_save(bst_fullfile(ProtocolInfo.SUBJECTS, sSubject.FileName), matUpdate, 'v7', 1);
@@ -107,5 +105,6 @@ if isUpdate
     end
 end
 
-
+% Unlock Subject
+lock_release([], LockId);
 

--- a/toolbox/db/lock_acquire.m
+++ b/toolbox/db/lock_acquire.m
@@ -37,7 +37,7 @@ sqlConnection = sql_connect();
 
 % Get subject ID
 if ischar(SubjectId)
-    sSubject = sql_query(sqlConnection, 'select', 'subject', 'Id', struct('Name', SubjectId));
+    sSubject = db_get(sqlConnection, 'Subject', SubjectId, 'Id');
     SubjectId = sSubject.Id;
 end
 

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1247,13 +1247,15 @@ function SetStandardView(hFig, viewNames)
     % Displaying a surface: Load the SCS field from the MRI
     if isempty(Ranat) && ~isempty(TessInfo) && ~isempty(TessInfo(1).SurfaceFile)
         % Get subject
-        sAnatomyFile = db_get('AnatomyFile', TessInfo(1).SurfaceFile, 'Subject');
-        sSubject  = db_get('Subject', sAnatomyFile.Subject, 'iAnatomy');
-        [~, sMriFile]  = db_get('AnatomyFile', sSubject.iAnatomy);
+        sqlConn = sql_connect();
+        sAnatomyFile = db_get(sqlConn, 'AnatomyFile', TessInfo(1).SurfaceFile, 'Subject');
+        sSubject     = db_get(sqlConn, 'Subject', sAnatomyFile.Subject, 'iAnatomy');
+        sAnatomyFile = db_get(sqlConn, 'AnatomyFile', sSubject.iAnatomy);
+        sql_close(sqlConn);
         % If there is an MRI associated with it
-        if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy) && ~isempty(sMriFile.FileName)
+        if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy) && ~isempty(sAnatomyFile.FileName)
             % Load the SCS+MNI transformation from this file
-            sMri = load(file_fullpath(sMriFile.FileName), 'NCS', 'SCS', 'Comment');
+            sMri = load(file_fullpath(sAnatomyFile.FileName), 'NCS', 'SCS', 'Comment');
             if isfield(sMri, 'NCS') && isfield(sMri.NCS, 'R') && ~isempty(sMri.NCS.R) && isfield(sMri, 'SCS') && isfield(sMri.SCS, 'R') && ~isempty(sMri.SCS.R)
                 % Calculate the SCS => MNI rotation   (inverse(MRI=>SCS) * MRI=>MNI)
                 Ranat = sMri.NCS.R * pinv(sMri.SCS.R);

--- a/toolbox/gui/panel_protocols.m
+++ b/toolbox/gui/panel_protocols.m
@@ -500,7 +500,7 @@ function CreateStudyNode(nodeStudy) %#ok<DEFNU>
     if iStudy ~= 0
         sqlConn = sql_connect();
         sStudy = sql_query(sqlConn, 'select', 'study', '*', struct('Id', iStudy));
-        sSubject = sql_query(sqlConn, 'select', 'subject', 'UseDefaultChannel', struct('Id', sStudy.Subject));
+        sSubject = db_get(sqlConn, 'Subject', sStudy.Subject, 'UseDefaultChannel');
         sql_close(sqlConn);
         if ~isempty(sStudy)
             % Get selected search tab
@@ -691,7 +691,7 @@ function UpdateNode(category, indices, isExpandTrials)
                             % Get study and associated subject
                             sqlConn = sql_connect();
                             sStudy = sql_query(sqlConn, 'select', 'Study', '*', struct('Id', iStudy));
-                            sSubject = sql_query(sqlConn, 'select', 'Subject', 'UseDefaultChannel', struct('Id', sStudy.Subject));
+                            sSubject = db_get(sqlConn, 'Subject', sStudy.Subject, 'UseDefaultChannel');
                             sql_close(sqlConn);
                             % Create new study node (default node / normal node)
                             UseDefaultChannel = ~isempty(sSubject) && (sSubject.UseDefaultChannel ~= 0);

--- a/toolbox/gui/panel_scout.m
+++ b/toolbox/gui/panel_scout.m
@@ -4051,14 +4051,16 @@ function PlotScouts(iScouts, hFigSel)
         return;
     end
     % Get anatomy file
-    sFile    = db_get('SurfaceFile', sSurf.FileName, 'Subject');
-    sSubject = db_get('Subject', sFile.Subject, 'iAnatomy');    
+    sqlConn = sql_connect();
+    sAnatomyFile = db_get(sqlConn, 'AnatomyFile', sSurf.FileName, 'Subject');
+    sSubject     = db_get(sqlConn, 'Subject', sAnatomyFile.Subject, 'iAnatomy');    
     % Volume scouts: Get number of points for this atlas
     [isVolumeAtlas, nAtlasGrid] = ParseVolumeAtlas(sAtlas.Name);
     isStructAtlas = ismember(sAtlas.Name, {'Structures', 'Source model'});
     % Get cortex + anatomy
-    sFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
-    SurfaceFiles = {sSurf.FileName, sFile.FileName};
+    sAnatomyFile = db_get(sqlConn, 'AnatomyFile', sSubject.iAnatomy, 'FileName');
+    sql_close(sqlConn);
+    SurfaceFiles = {sSurf.FileName, sAnatomyFile.FileName};
     % Get all the figures concerned with Scout cortex and/or MRI surface
     [hFigures, iFigures, iDataSets, iSurfaces] = bst_figures('GetFigureWithSurface', SurfaceFiles);
     if isempty(hFigures)

--- a/toolbox/gui/view_surface.m
+++ b/toolbox/gui/view_surface.m
@@ -70,8 +70,10 @@ end
 
 %% ===== GET INFORMATION =====
 % Get Subject that holds this surface
-sAnatomyFile = db_get('AnatomyFile', SurfaceFile);
-sSubject = db_get('Subject', sAnatomyFile.Subject);
+sqlConn = sql_connect();
+sAnatomyFile = db_get(sqlConn, 'AnatomyFile', SurfaceFile);
+sSubject     = db_get(sqlConn, 'Subject', sAnatomyFile.Subject);
+sql_close(sqlConn);
 % If this surface does not belong to any subject
 if isempty(iDS)
     if isempty(sSubject)

--- a/toolbox/tree/node_create_db_studies.m
+++ b/toolbox/tree/node_create_db_studies.m
@@ -73,7 +73,7 @@ end
 sqlConn = sql_connect();
 sDefaultStudy  = sql_query(sqlConn, 'select', 'study', {'Id', 'FileName'}, struct('Subject', 0, 'Name', bst_get('DirDefaultStudy')));
 sAnalysisStudy = sql_query(sqlConn, 'select', 'study', {'Id', 'FileName'}, struct('Name', bst_get('DirAnalysisInter')));
-sSubjects = sql_query(sqlConn, 'select', 'subject', '*');
+sSubjects = db_get(sqlConn, 'Subjects', 1);
 sql_close(sqlConn);
 iDefaultSubject = find(strcmp({sSubjects.Name}, bst_get('DirDefaultSubject')), 1);
 iGroupSubject   = find(strcmp({sSubjects.Name}, bst_get('NormalizedSubjectName')), 1);

--- a/toolbox/tree/node_create_db_subjects.m
+++ b/toolbox/tree/node_create_db_subjects.m
@@ -56,7 +56,7 @@ if (isempty(ProtocolInfo))
     return
 end
 % Get current protocol subjects list
-sSubjects = sql_query([], 'select', 'subject', '*');
+sSubjects = db_get('Subjects', 1);
 iDefaultSubject = find(strcmp({sSubjects.Name}, bst_get('DirDefaultSubject')), 1);
 
 %TODO: Save current study in GlobalData, retrieve current subject and return it as bstDefaultNode

--- a/toolbox/tree/node_create_subject.m
+++ b/toolbox/tree/node_create_subject.m
@@ -66,11 +66,14 @@ if sSubject.UseDefaultAnat && (iSubject ~= 0)
 % ==== Individual anatomy ====
 else
     sqlConn = sql_connect();
-    anatomies = sql_query(sqlConn, 'select', 'anatomyfile', '*', ...
-        struct('subject', iSubject, 'type', 'anatomy'), 'ORDER BY Id ASC');
-    surfaces  = sql_query(sqlConn, 'select', 'anatomyfile', '*', ...
-        struct('subject', iSubject, 'type', 'surface'), 'ORDER BY Id ASC');
+    anatomies = db_get(sqlConn, 'FilesWithSubject', iSubject, 'anatomy');
+    surfaces  = db_get(sqlConn, 'FilesWithSubject', iSubject, 'surface');
     sql_close(sqlConn);
+    % Sort by Id
+    [~, ixs] = sort([anatomies.Id]);
+    anatomies = anatomies(ixs);
+    [~, ixs] = sort([surfaces.Id]);
+    surfaces = surfaces(ixs);
     
     % Create list of anat files (put the default at the top)
     nAnatomies = length(anatomies);


### PR DESCRIPTION
This PR restructures bst_get, bst_set, db_get and db_set
- Select and Count queries for AnatomyFile and Subject tables are done with db_get  
- Delete, Insert and Update queries for AnatomyFile and Subject tables are done with db_set
- bst_get and bst_set use db_get and db_set to R/W in AnatomyFile and Subject tables
- db_get and db_set make only use of the new structures with empty "skip" fields
- Functional tree callback SetDefaultSurf (right click on non-default surface and "Set as default surfaceType"