### PR TITLE
Improve creation of and updates to SQLite DB

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -692,7 +692,7 @@ switch contextName
                 
                 % === Populate functional files data
                 sFuncFiles = db_get(sqlConn, 'FunctionalFilesWithStudy', iStudy);
-                % Names of fields in sStudy for types of functional files
+                % Names of fields in sStudy for types of functional files (datalist and matrixlist are ignored)
                 types = {'Channel', 'Data', 'HeadModel', 'Result', 'Stat', ...
                          'Image', 'NoiseCov', 'Dipoles', 'Timefreq', 'Matrix'};
                 for ix_type = 1 : length(types)

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -178,11 +178,11 @@ switch contextName
         [~, ia, ib] = setxor([sSubjectsOld.Id],[sSubjects.Id]);
         ia = sort(ia);
         ib = sort(ib);
-        % Delete Subjects (and their Anatomy Files) in DB, but not in sSubjects
+        % Delete Subjects (and their Anatomy Files) present in DB but not in sSubjects
         for ix = 1 : length(ia)
             db_set(sqlConn, 'Subject', 'Delete', sSubjectsOld(ia(ix)).Id);
         end
-        % Insert Subjects and their Anatomy Files in sSubjects but not in DB
+        % Insert Subjects (and their Anatomy Files) present in sSubjects but not in DB
         for ix = 1 : length(ib)
             db_set(sqlConn, 'ParsedSubject', sSubjects(ib(ix)));
         end

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -248,6 +248,7 @@ switch contextName
 
 %% ==== SUBJECT ====
     case 'Subject'
+        warning('bst_set(''%s'') will be deprecated in new Brainstorm database system. Use db_set(''%s'')', contextName, 'ParsedSubject or Subject');
         iSubject = varargin{2};
         sSubject = varargin{3};
         sqlConn = sql_connect();
@@ -300,6 +301,8 @@ switch contextName
         
 %% ==== STUDY ====
     case 'Study'
+        warning('bst_set(''%s'') will be deprecated in new Brainstorm database system. Use db_set(''%s'')', contextName, 'ParsedStudy or Study');
+
         % Get studies list
         iStudies = varargin{2};
         sStudies = varargin{3};

--- a/toolbox/core/bst_set.m
+++ b/toolbox/core/bst_set.m
@@ -168,7 +168,7 @@ switch contextName
             end
         end
         % Get all Subjects
-        sSubjectsOld = db_get('AllSubjects', 'Id', '@default_subject');
+        sSubjectsOld = db_get(sqlConn, 'AllSubjects', 'Id', '@default_subject');
         % Update Subjects and their Anatomy Files
         [~, ~, ib] = intersect([sSubjectsOld.Id],[sSubjects.Id]);
         for ix = 1 : length(ib)
@@ -212,7 +212,7 @@ switch contextName
             end
         end
         % Get all Studies
-        sStudiesOld = db_get('AllStudies', 'Id', '@inter', '@default_study');
+        sStudiesOld = db_get(sqlConn, 'AllStudies', 'Id', '@inter', '@default_study');
 
         % Update Studies and their Functional Files
         [~, ~, ib] = intersect([sStudiesOld.Id],[sStudies.Id]);
@@ -231,9 +231,9 @@ switch contextName
         for ix = 1 : length(ib)
             db_set(sqlConn, 'ParsedStudy', sStudies(ib(ix)));
         end
-        sql_close(sqlConn);
         % Update links
-        db_links();
+        db_links(sqlConn);
+        sql_close(sqlConn);
         
         
     case 'ProtocolInfo'
@@ -288,10 +288,10 @@ switch contextName
         
         % If subject exists, UPDATE
         if ~isempty(sExistingSubject)
-            iSubject  = db_set('ParsedSubject', sSubject, sExistingSubject.Id);
+            iSubject  = db_set(sqlConn, 'ParsedSubject', sSubject, sExistingSubject.Id);
         % If subject is new, INSERT
         else
-            iSubject  = db_set('ParsedSubject', sSubject);
+            iSubject  = db_set(sqlConn, 'ParsedSubject', sSubject);
         end
         if ~isempty(iSubject)
             argout1 = iSubject;
@@ -335,18 +335,18 @@ switch contextName
             end
             % If study exists, UPDATE
             if ~isempty(sExistingStudy)
-                iStudy  = db_set('ParsedStudy', sStudy, sExistingStudy.Id);
+                iStudy  = db_set(sqlConn, 'ParsedStudy', sStudy, sExistingStudy.Id);
             % If subject is new, INSERT
             else
-                iStudy  = db_set('ParsedStudy', sStudy);
+                iStudy  = db_set(sqlConn, 'ParsedStudy', sStudy);
             end
             iStudiesOut = [iStudiesOut, iStudy];
         end
         if ~isempty(iStudiesOut)
             argout1 = iStudiesOut;
         end
+        db_links(sqlConn, 'Study', iStudiesOut);
         sql_close(sqlConn);
-        db_links('Study', iStudiesOut);
         
         
 %% ==== GUI ====

--- a/toolbox/db/db_convert_anatomyfile.m
+++ b/toolbox/db/db_convert_anatomyfile.m
@@ -34,17 +34,13 @@ if (nargin < 2) || isempty(type)
 end
 
 % Output
-outStructs = [];
-
 nStructs = length(inStructs);
-if nStructs < 1
-    return
-end 
 
 % Verify the sense of the conversion
 % New to old
-if all(isfield(inStructs(1), {'Id', 'Type'}))
+if all(isfield(inStructs, {'Id', 'Type'}))
     % Old structures should be of the same type
+    outStructs = [];
     if length(unique({inStructs.Type})) == 1
         outStructs = repmat(db_template(inStructs(1).Type), 1, nStructs);
         for iStruct = 1 : nStructs

--- a/toolbox/db/db_convert_anatomyfile.m
+++ b/toolbox/db/db_convert_anatomyfile.m
@@ -33,7 +33,6 @@ if (nargin < 2) || isempty(type)
     type = '';
 end
 
-% Output
 nStructs = length(inStructs);
 
 % Verify the sense of the conversion

--- a/toolbox/db/db_convert_functionalfile.m
+++ b/toolbox/db/db_convert_functionalfile.m
@@ -45,7 +45,6 @@ if (nargin < 2) || isempty(type)
     type = '';
 end
 
-% Output
 nStructs = length(inStructs);
 
 % Verify the sense of the conversion

--- a/toolbox/db/db_convert_functionalfile.m
+++ b/toolbox/db/db_convert_functionalfile.m
@@ -46,17 +46,13 @@ if (nargin < 2) || isempty(type)
 end
 
 % Output
-outStructs = [];
-
 nStructs = length(inStructs);
-if nStructs < 1
-    return
-end 
 
 % Verify the sense of the conversion
 % New to old
-if all(isfield(inStructs(1), {'Id', 'Type'}))
+if all(isfield(inStructs, {'Id', 'Type'}))
     % Old structures should be of the same type 
+    outStructs = [];
     if length(unique({inStructs.Type})) == 1
         outStructs = repmat(db_template(inStructs(1).Type), 1, nStructs);
         for iStruct = 1 : nStructs 

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -794,10 +794,10 @@ switch contextName
         end
         addQuery = '';
         % Complete query with studies ("@inter" and global "@default_study")
-        if length(args) < 2 || ~ismember('@inter', args(3:end))
+        if length(args) < 2 || ~ismember('@inter', args(2:end))
             addQuery = [addQuery ' AND Name <> "' bst_get('DirAnalysisInter') '"'];
         end
-        if length(args) < 2 || ~ismember('@default_study', args(3:end))
+        if length(args) < 2 || ~ismember('@default_study', args(2:end))
             addQuery = [addQuery ' AND (Subject <> 0 OR Name <> "@default_study")'];
         end
         

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -638,8 +638,9 @@ switch contextName
 
 
 %% ==== STUDIES FROM SUBJECT ====        
-    % sStudies = db_get('StudiesFromSubject', iSubject,        Fields)                             % Exclude '@intra' study and '@default_study')
-    %          = db_get('StudiesFromSubject', iSubject,        Fields, '@intra', '@default_study') % Include '@intra' study and '@default_study')
+    % sStudies = db_get('StudiesFromSubject', iSubject,        Fields)                             % Exclude '@intra' study and '@default_study'
+    %          = db_get('StudiesFromSubject', iSubject,        Fields, '@intra', '@default_study') % Include '@intra' study and '@default_study'
+    %          = db_get('StudiesFromSubject', iSubject,        Fields, '@inter', '@default_study') % Include '@inter' study and global '@default_study', only for iSubject = 0
     %          = db_get('StudiesFromSubject', SubjectFileName, Fields)
     %          = db_get('StudiesFromSubject', SubjectName,     Fields)
     case 'StudiesFromSubject'
@@ -673,6 +674,9 @@ switch contextName
         end
         if length(args) < 2 || ~ismember('@default_study', args(3:end))
             addQuery = [addQuery ' AND Study.Name <> "' bst_get('DirDefaultStudy') '"'];
+        end
+        if length(args) < 2 || ~ismember('@inter', args(3:end))
+            addQuery = [addQuery ' AND Study.Name <> "' bst_get('DirAnalysisInter') '"'];
         end
         % Select query
         varargout{1} = sql_query(sqlConn, 'SELECT', joinQry, [], fields, addQuery);

--- a/toolbox/db/db_links.m
+++ b/toolbox/db/db_links.m
@@ -1,13 +1,15 @@
 function OutputLinks = db_links(varargin)
 % DB_LINKS: Update all the links to shared results files.
 %
-% USAGE:  OutputLinks = db_links('Subject', iSubject)
-%         OutputLinks = db_links('Subject', SubjectFile)
-%         OutputLinks = db_links('Study',   iStudiesList) : Process only the target studies (they must belong to the same subject)
-%         OutputLinks = db_links()                        : Process all the subjects of the current protocol
+% USAGE:  OutputLinks = db_links(sqlConn, 'Subject', iSubject)
+%         OutputLinks = db_links(sqlConn, 'Subject', SubjectFile)
+%         OutputLinks = db_links(sqlConn, 'Study',   iStudiesList) : Process only the target studies (they must belong to the same subject)
+%         OutputLinks = db_links(sqlConn)                          : Process all the subjects of the current protocol
 %
-% OUTPUT: List of links created
-
+%         Argument 'sqlConn' is optional, and is the connection with JDBC
+%
+% OUTPUT: Links are added to DataBase st of links created
+%
 % @=============================================================================
 % This function is part of the Brainstorm software:
 % https://neuroimage.usc.edu/brainstorm
@@ -27,74 +29,87 @@ function OutputLinks = db_links(varargin)
 % =============================================================================@
 %
 % Authors: Francois Tadel, 2008-2013
+%          Raymundo Cassani, 2022-2023
 
 %% ===== PARSE INPUTS =====
+if (length(varargin) > 0) && isjava(varargin{1})
+    sqlConn = varargin{1};
+    varargin(1) = [];
+    handleConn = 0;
+else
+    sqlConn = sql_connect();
+    handleConn = 1;
+end
+
 OutputLinks = {};
 % CALL: db_links()
-if (nargin == 0)
-    % Get subjects list
-    sSubjectsList = bst_get('ProtocolSubjects');
+if (length(varargin) == 0)
+    % For all other subjects, except default subject
+    sSubjects = db_get(sqlConn, 'AllSubjects', 'Id');
     % Update results links for global default study
-    db_links('Subject', 0);
+    db_links(sqlConn, 'Subject', 0);
     % For all other subjects
-    for iSubject = 1:length(sSubjectsList.Subject)
+    for iSubject = 1:length(sSubjects)
         % If subject do not share channel file (already processed)
         %if (sSubjectsList.Subject(iSubject).UseDefaultChannel ~= 0)
             % Update results links for subject
-            db_links('Subject', sSubjectsList.Subject(iSubject).Id);
+            db_links(sqlConn, 'Subject', sSubjects(iSubject).Id);
         %end
     end
     % Hide progress bar
     %bst_progress('stop');
+    exit_db_links();
     return
 % CALL: db_links('Subject', ...)
-elseif (nargin == 2) && ischar(varargin{1}) && strcmpi(varargin{1}, 'Subject')
+elseif (length(varargin) == 2) && ischar(varargin{1}) && strcmpi(varargin{1}, 'Subject')
     % CALL: db_links('Subject', SubjectFile)
     if ischar(varargin{2})
         SubjectFile = varargin{2};
-        [sSubject, iSubject] = bst_get('Subject', SubjectFile, 1);
+        sSubject = db_get(sqlConn, 'Subject', SubjectFile, '*', 1);
     % CALL: db_links('Subject', iSubject)
     else
         iSubject = varargin{2};
         if (length(iSubject) > 1)
             error('Cannot process more than one subject.');
         end
-        sSubject = bst_get('Subject', iSubject, 1);
+        sSubject = db_get(sqlConn, 'Subject', iSubject, '*', 1);
     end
     % Check for weird bugs
     if isempty(sSubject)
         warning('Default subject cannot be reached for this protocol.');
+        exit_db_links();
         return
     end
-    % Get all the studies related for this subject
-    [sStudiesList, iStudiesList] = bst_get('StudyWithSubject', sSubject.FileName, 'intra_subject', 'inter_subject');
+    % Get all the studies: including @inter and global  @default_study for default subject
+    %                      including @intra and subject @default_study for any other subject
+    sStudiesList = db_get(sqlConn, 'StudiesFromSubject', sSubject.Id, {'Id', 'Subject'}, '@inter', '@intra', '@default_study');
 % CALL: db_links('Studies', iStudiesList)
-elseif (nargin == 2) && ischar(varargin{1}) && strcmpi(varargin{1}, 'Study')
+elseif (length(varargin) == 2) && ischar(varargin{1}) && strcmpi(varargin{1}, 'Study')
     % Get studies list
-    iStudiesList = varargin{2};
-    sStudiesList = bst_get('Study', iStudiesList);
+    sStudiesList = db_get(sqlConn, 'Study', varargin{2}, {'Id', 'Subject'});
     % Check that they all have the same subject
-    subjectsDirs = cellfun(@(c)bst_fileparts(c), {sStudiesList.BrainStormSubject}, 'UniformOutput', 0);
-    [uniqueSubjects, I, J] = unique(subjectsDirs);
+    [uniqueSubjects, I, J] = unique([sStudiesList.Subject]);
     if (length(uniqueSubjects) ~= 1)
         % If it is not the case: call again the function as many times as needed
         for i = 1:length(uniqueSubjects)
             % Get all the studies for subject #i
             iStudiesSubj = find(J == i);
             % Call this function only with the studies for the subject #i
-            OutputLinks = cat(2, OutputLinks, db_links('Study', iStudiesList(iStudiesSubj)));
+            OutputLinks = cat(2, OutputLinks, db_links(sqlConn, 'Study', sStudiesList(iStudiesSubj).Id));
         end
+        exit_db_links();
         return;
     else
-        SubjectFile = uniqueSubjects{1};
+        SubjectFile = uniqueSubjects(1);
     end
     % Get subject
-    [sSubject, iSubject] = bst_get('Subject', SubjectFile);
+    sSubject = db_get(sqlConn, 'Subject', SubjectFile, {'Id', 'UseDefaultChannel'});
 else
     error('Invalid call');
 end
 % Invalid subject: return
 if isempty(sSubject)
+    exit_db_links();
     return
 end
 
@@ -103,17 +118,19 @@ end
 % Progress bar
 isNewProgressBar = ~bst_progress('isvisible');
 if isNewProgressBar
-    bst_progress('start', 'Update results links', 'Updating results links...', 1, length(iStudiesList));
+    bst_progress('start', 'Update results links', 'Updating results links...', 1, length(sStudiesList));
 else
     %bst_progress('text', 'Updating results links...');
 end
 % Get the default study for this subject
-sDefaultStudy = bst_get('DefaultStudy', iSubject);
+sDefaultStudy = db_get(sqlConn, 'DefaultStudy', sSubject.Id, 'Id');
+% Get 'result' FunctionalFiles
+sResultFiles = db_get(sqlConn, 'FunctionalFilesWithStudy', sDefaultStudy.Id, '*', 'result');
 
 % === CREATE NEW LINKS TEMPLATES ===
 % Link to default study
-if ((iSubject == 0) || (sSubject.UseDefaultChannel ~= 0)) && ~isempty(sDefaultStudy) && ~isempty(sDefaultStudy.Result)
-    [sLinksList, linkResultFiles] = createLinksMat(sDefaultStudy.Result);    
+if ((sSubject.Id == 0) || (sSubject.UseDefaultChannel ~= 0)) && ~isempty(sDefaultStudy) && ~isempty(sResultFiles)
+    [sLinksList, linkResultFiles] = createLinksMat(sResultFiles);
 else
     sLinksList = [];
     linkResultFiles = [];
@@ -121,17 +138,19 @@ end
 
 %% ===== PROCESS EACH STUDY =====
 % For each study
-for iStudy = 1:length(iStudiesList)
+for iStudy = 1:length(sStudiesList)
     % === GET LOCAL SHARED RESULTS ===
-    sStudySubject = bst_get('Subject', sStudiesList(iStudy).BrainStormSubject);
+    sStudySubject = db_get(sqlConn, 'Subject', sStudiesList(iStudy).Subject, {'Id', 'UseDefaultChannel'});
+    % Get all 'result' functional files for study
+    sResultFiles = db_get(sqlConn, 'FunctionalFilesWithStudy', sStudiesList(iStudy).Id, '*', 'result');
     if (sStudySubject.UseDefaultChannel == 0)
         % Get the results that do not have any DataFile attached => shared imaging kernels
-        iSharedRes = find(cellfun(@isempty, {sStudiesList(iStudy).Result.DataFile}) ...
-                          & ~[sStudiesList(iStudy).Result.isLink] ...
-                          & ~cellfun(@isempty, strfind({sStudiesList(iStudy).Result.FileName}, '_KERNEL_')));
+        iSharedRes = find(cellfun(@isempty, {sResultFiles.ExtraStr1}) ... % no DataFile attached
+                          & ~[sResultFiles.ExtraNum] ...                  % is not a link
+                          & ~cellfun(@isempty, strfind({sResultFiles.FileName}, '_KERNEL_'))); % '_KERNEL_' in FileName
         % Create links to local shared kernels
         if ~isempty(iSharedRes)
-            [sLinksList, linkResultFiles] = createLinksMat(sStudiesList(iStudy).Result(iSharedRes));  
+            [sLinksList, linkResultFiles] = createLinksMat(sResultFiles(iSharedRes));
         else
             sLinksList = [];
             linkResultFiles = [];
@@ -140,44 +159,68 @@ for iStudy = 1:length(iStudiesList)
 
     % === REMOVE OLD LINKS ===
     % Get the a list of the previous results-links
-    iOldLinkRes = find([sStudiesList(iStudy).Result.isLink]);
-    if ~isempty(iOldLinkRes)
-        % Remove them from database
-        sStudiesList(iStudy).Result(iOldLinkRes) = [];
+    sOldLinkRes = find([sResultFiles.ExtraNum]); % isLink
+    if ~isempty(sOldLinkRes)
+        for ix = 1 : length(sOldLinkRes)
+        % Find Children for these links and remove the link as Parent
+        sChildFiles = db_get(sqlConn, 'ChildrenFromFunctionalFile', sResultFiles(sOldLinkRes(ix)).Id, 'Id');
+        for ij = 1 : length(sChildFiles)
+            db_set(sqlConn, 'FunctionalFile', struct('Parent', []), sChildFiles(ij).Id);
+        end
+        % Remove links from database
+        db_set(sqlConn, 'FunctionalFile', 'Delete', sResultFiles(sOldLinkRes(ix)).Id);
+        end
     end
     
     % === CREATE NEW LINKS ===
-    nData = length(sStudiesList(iStudy).Data);
+    sDataFiles = db_get(sqlConn, 'FunctionalFilesWithStudy', sStudiesList(iStudy).Id, '*', 'data');
+    nData = length(sDataFiles);
     for iData = 1:nData
         % Data structure
-        sData = sStudiesList(iStudy).Data(iData);
+        sData = sDataFiles(iData);
         % Check that the file is a real recordings file
-        if ~strcmpi(sData.DataType, 'recordings') && ~strcmpi(sData.DataType, 'raw')
+        if ~strcmpi(sData.SubType, 'recordings') && ~strcmpi(sData.SubType, 'raw')
             continue;
         end
         % Build one link for each common results file and for each data file
         for iLink = 1:length(sLinksList)
             % Build new link entry
-            sLinksList(iLink).DataFile = file_win2unix(sData.FileName);
-            sLinksList(iLink).FileName = ['link|', linkResultFiles{iLink}, '|', sLinksList(iLink).DataFile];
-            % Add link to study
-            sStudiesList(iStudy).Result(end+1) = sLinksList(iLink);
+            sLinksList(iLink).ExtraStr1 = file_win2unix(sData.FileName); % .DataFile
+            sLinksList(iLink).Parent = sData.Id;
+            sLinksList(iLink).Id = [];
+            sLinksList(iLink).FileName  = ['link|', linkResultFiles{iLink}, '|', sLinksList(iLink).ExtraStr1];
+            % Add link to database
+            linkId = db_set(sqlConn, 'FunctionalFile', sLinksList(iLink));
+            % Find children for created links
+            sChildFiles = db_get(sqlConn, 'FunctionalFile', struct('ExtraStr1', sLinksList(iLink).FileName), 'Id');
+            for ij = 1 : length(sChildFiles)
+                db_set(sqlConn, 'FunctionalFile', struct('Parent', linkId), sChildFiles(ij).Id);
+            end
+            % Udpate children count for links (Because childrend were in DB before link was created)
+            db_set(sqlConn, 'FunctionalFile', struct('NumChildren', length(sChildFiles)), linkId);
             OutputLinks{end+1} = sLinksList(iLink).FileName;
         end
     end
+
     % Increment progress bar
     if isNewProgressBar
         bst_progress('inc', 1);
     end
-    % Update study in database
-    bst_set('Study', iStudiesList(iStudy), sStudiesList(iStudy));
 end
 
 % Close progress bar
 if isNewProgressBar
     bst_progress('stop');
 end
+% Handle SQL connection
+exit_db_links();
 
+% Exiting db_links, close SQL connnection if it was opened
+function exit_db_links()
+    if handleConn
+        sql_close(sqlConn);
+    end
+end
 
 end
 
@@ -186,14 +229,16 @@ end
 %  ====== HELPERS =================================================================================
 %  ================================================================================================
 function [sLinksList, linkResultFiles] = createLinksMat(Results)
-    sLinksList = repmat(db_template('results'), 1, length(Results));
+    sLinksList = repmat(db_template('functionalfile'), 1, length(Results));
     linkResultFiles = cell(1,length(Results));
     for iRes = 1:length(Results)
-        % Create 'results' structure to be stored in database
-        sLinksList(iRes).Comment  = Results(iRes).Comment;
-        sLinksList(iRes).FileName = '';
-        sLinksList(iRes).isLink   = 1;
-        sLinksList(iRes).HeadModelType = Results(iRes).HeadModelType;
+        % Create 'FunctionalFile' structure to be stored in database
+        sLinksList(iRes).Study     = Results(iRes).Study;
+        sLinksList(iRes).Type      = Results(iRes).Type;
+        sLinksList(iRes).FileName  = '';
+        sLinksList(iRes).Comment   = Results(iRes).Comment;
+        sLinksList(iRes).ExtraNum  = 1;                       % .isLink
+        sLinksList(iRes).ExtraStr2 = Results(iRes).ExtraStr2; % .HeadModelType
         linkResultFiles{iRes} = file_win2unix(Results(iRes).FileName);
     end
 end

--- a/toolbox/db/db_load_protocol.m
+++ b/toolbox/db/db_load_protocol.m
@@ -54,7 +54,7 @@ for i = 1:length(iProtocols)
     else
         % Load database info about protocol
         sqlConn = sql_connect(dbInfo);
-        sProtocol = db_get('Protocol', {'UseDefaultAnat', 'UseDefaultChannel'});
+        sProtocol = db_get(sqlConn, 'Protocol', {'UseDefaultAnat', 'UseDefaultChannel'});
         sql_close(sqlConn, dbInfo);
         %TODO: iStudy
         %GlobalData.DataBase.ProtocolInfo(iProtocols(i)).iStudy            = ProtocolMat.ProtocolInfo.iStudy;

--- a/toolbox/db/db_load_subjects.m
+++ b/toolbox/db/db_load_subjects.m
@@ -118,14 +118,20 @@ end
 
 
 %% ===== PROCESS ALL FILES IN SUBJECTS DIRECTORY =====
-ProtocolSubjects = db_template('ProtocolSubjects');
 % Parse SUBJECTS/<DirDefaultSubject>/ directory, if it exists
-ProtocolSubjects.DefaultSubject = db_parse_subject(ProtocolInfo.SUBJECTS, bst_get('DirDefaultSubject'), 5);
+sParsedDefaultSubject = db_parse_subject(ProtocolInfo.SUBJECTS, bst_get('DirDefaultSubject'), 5);
 % Parse SUBJECTS directory ('DirDefaultSubject' directories will be ignored)
-ProtocolSubjects.Subject = db_parse_subject(ProtocolInfo.SUBJECTS, '', 45);
-% Update protocol in DataBase
-bst_set('ProtocolSubjects', ProtocolSubjects);
+sParsedSubjects = db_parse_subject(ProtocolInfo.SUBJECTS, '', 45);
 
+sqlConn = sql_connect();
+% Delete existing Subjects and AnatomyFiles
+db_set(sqlConn, 'Subject', 'delete');
+db_set(sqlConn, 'AnatomyFile', 'delete');
+% Update Subjects in DataBase
+sSubjects = [sParsedDefaultSubject, sParsedSubjects];
+for ix = 1 : length(sSubjects)
+    db_set(sqlConn, 'ParsedSubject', sSubjects(ix));
+end
 
 %% ===== SUBJECTS TEMPLATE =====
 % If Default anat status not defined for protocol

--- a/toolbox/db/db_reload_studies.m
+++ b/toolbox/db/db_reload_studies.m
@@ -44,9 +44,14 @@ end
 % Process
 for iStudy = iStudies
     % Get study
-    sStudy = bst_get('Study', iStudy);
+    sStudy = db_get('Study', iStudy);
     if isempty(sStudy)
         continue;
+    end
+    % Get HeadModel filename
+    if ~isempty(sStudy.iHeadModel)
+        sHeadModelFile = db_get('FunctionalFile', sStudy.iHeadModel, 'FileName');
+        sStudy.iHeadModel = sHeadModelFile.FileName;
     end
     % Get study directory
     studySubDir = bst_fileparts(sStudy.FileName);
@@ -65,14 +70,11 @@ for iStudy = iStudies
         return
     end
     % Try to reuse the existing selection of headmodel (which is not saved on the hard drive)
-    if ~isempty(sStudy.HeadModel) && ~isempty(sStudy.iHeadModel) && ~isempty(sStudyNew.HeadModel)
-        sStudyNew.iHeadModel = find(strcmp(sStudy.HeadModel(sStudy.iHeadModel).FileName, {sStudyNew.HeadModel.FileName}));
-    end
-    if ~isempty(sStudy.iHeadModel) && (sStudy.iHeadModel <= length(sStudyNew.HeadModel)) && isempty(sStudyNew.iHeadModel)
+    if ~isempty(sStudy.iHeadModel) && ~isempty(sStudyNew.HeadModel) && ismember(sStudy.iHeadModel, {sStudyNew.HeadModel.FileName})
         sStudyNew.iHeadModel = sStudy.iHeadModel;
     end
     % Else study was reloaded
-    bst_set('Study', iStudy, sStudyNew);
+    db_set('ParsedStudy', sStudyNew, iStudy);
 end
 
 % Update display

--- a/toolbox/db/db_reload_subjects.m
+++ b/toolbox/db/db_reload_subjects.m
@@ -66,7 +66,7 @@ for i = 1:length(iSubjects)
         return
     end
     % Else subject was reloaded: update in database
-    bst_set('Subject', iSubjects(i), sSubject);
+    db_set(sqlConn, 'ParsedSubject', sSubject);
 end
 sql_close(sqlConn);
 

--- a/toolbox/db/db_reload_subjects.m
+++ b/toolbox/db/db_reload_subjects.m
@@ -66,14 +66,14 @@ for i = 1:length(iSubjects)
         return
     end
     % Else subject was reloaded: update in database
-    db_set(sqlConn, 'ParsedSubject', sSubject);
+    db_set(sqlConn, 'ParsedSubject', sSubject, iSubjects(i));
 end
 sql_close(sqlConn);
 
 % Update display
 panel_protocols('UpdateNode', 'Subject', iSubjects);
 % Save database
-db_save();
+% db_save();
 % Hide progress bar if it was started here
 if isProgressBar
     bst_progress('stop');

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -317,11 +317,12 @@ switch contextName
             varargout{1} = 1;
         % Insert or Update AnatomyFiles to SubjectID
         else
+            [sAnatFiles.Subject] = deal(iSubject);
             sAnatFilesOld = db_get('AnatomyFilesWithSubject', iSubject);
-            % Files to update
+            % Files to Update
             [~, ia, ib] = intersect({sAnatFilesOld.FileName},{sAnatFiles.FileName});
             for ix = 1 : length(ia)
-                if ~isEqualDbStructs(sAnatFilesOld(ia), sAnatFiles(ib))
+                if ~isEqualDbStructs(sAnatFilesOld(ia(ix)), sAnatFiles(ib(ix)))
                     db_set(sqlConn, 'AnatomyFile', sAnatFiles(ib(ix)), sAnatFilesOld(ia(ix)).Id);
                 end
             end
@@ -335,7 +336,6 @@ switch contextName
             end
             % Insert AnatomyFiles entries in parsed Subject but not in DB
             for ix = 1 : length(ib)
-                sAnatFiles(ib(ix)).Subject = iSubject;
                 db_set(sqlConn, 'AnatomyFile', sAnatFiles(ib(ix)));
             end
             % If requested get current AnatomyFiles

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -303,7 +303,6 @@ switch contextName
     case 'AnatomyFilesWithSubject'
         sAnatFiles = args{1};
         iSubject = args{2};
-        disp(iSubject);
         
         % Delete all AnatomyFiles with SubjectID
         if ischar(sAnatFiles) && strcmpi(sAnatFiles, 'delete')

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -401,7 +401,7 @@ switch contextName
         % Insert or Update AnatomyFiles to SubjectID
         else
             [sAnatFiles.Subject] = deal(iSubject);
-            sAnatFilesOld = db_get('AnatomyFilesWithSubject', iSubject);
+            sAnatFilesOld = db_get(sqlConn, 'AnatomyFilesWithSubject', iSubject);
             % Files to Update
             [~, ia, ib] = intersect({sAnatFilesOld.FileName},{sAnatFiles.FileName});
             for ix = 1 : length(ia)
@@ -413,11 +413,11 @@ switch contextName
             [~, ia, ib] = setxor({sAnatFilesOld.FileName},{sAnatFiles.FileName});
             ia = sort(ia);
             ib = sort(ib);
-            % Delete AnatomyFiles entries in DB, but not in parsed Subject
+            % Delete AnatomyFiles entries in DB, but not in Subject
             for ix = 1 : length(ia)
                 db_set(sqlConn, 'AnatomyFile', 'Delete', sAnatFilesOld(ia(ix)).Id);
             end
-            % Insert AnatomyFiles entries in parsed Subject but not in DB
+            % Insert AnatomyFiles entries in Subject but not in DB
             for ix = 1 : length(ib)
                 db_set(sqlConn, 'AnatomyFile', sAnatFiles(ib(ix)));
             end

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -108,12 +108,14 @@ switch contextName
 
 
 %% ==== PARSED SUBJECT ====
+    % iSubject = db_set('ParsedSubject', sParsedSubject)
     % iSubject = db_set('ParsedSubject', sParsedSubject, iSubject)
     case 'ParsedSubject'
-        sParsedSubject = varargin{2};  % sParsedSubjects is an array of old sSubject structure but iXxxx fields are be relative paths
+        sParsedSubject = args{1};  % sParsedSubject is old sSubject structure (with Anatomy and Surface fields).
+                                   % BUT default iXxxx fields are relative paths
         iSubject = [];
         if length(args) > 1
-            iSubject = varargin{3};
+            iSubject = args{2};
         end
 
         % Default Anatomy and Surface files
@@ -124,7 +126,7 @@ switch contextName
             sDefSurfFiles.(categories{iCat}) = sParsedSubject.(categories{iCat});
             sParsedSubject.(categories{iCat}) = [];
         end
-        % Anatomy and Surface files
+        % Get AnatomyFiles
         sAnatFiles = [db_convert_anatomyfile(sParsedSubject.Anatomy, 'volume'), ...
                       db_convert_anatomyfile(sParsedSubject.Surface, 'surface')];
         
@@ -150,7 +152,7 @@ switch contextName
         % Update indices in sSubject for default Anatomy and Surface files
         sDefSurfIds = struct(fieldValPairs{:});
         for iCat = 1 : length(categories)
-            if isfield(sDefSurfFiles, categories{iCat}) || ~isempty(sDefSurfFiles.(categories{iCat}))
+            if ~isempty(sDefSurfFiles.(categories{iCat}))
                 sAnatFile = db_get(sqlConn, 'AnatomyFile', sDefSurfFiles.(categories{iCat}), 'Id');
                 if ~isempty(sAnatFile)
                     sDefSurfIds.(categories{iCat}) = sAnatFile.Id;

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -535,13 +535,14 @@ switch contextName
 
         
 %% ==== FUNCTIONAL FILES ====
-    % Success                           = db_set('FunctionalFile', 'Delete')
-    %                                   = db_set('FunctionalFile', 'Delete', FunctionalFileId)
-    %                                   = db_set('FunctionalFile', 'Delete', CondQuery)
-    % FunctionalFileId, FunctionalFile] = db_set('FunctionalFile', FunctionalFile)
-    %                                   = db_set('FunctionalFile', FunctionalFile, FunctionalFileId)
+    % Success                            = db_set('FunctionalFile', 'Delete')
+    %                                    = db_set('FunctionalFile', 'Delete', FunctionalFileId)
+    %                                    = db_set('FunctionalFile', 'Delete', CondQuery)
+    % [FunctionalFileId, FunctionalFile] = db_set('FunctionalFile', FunctionalFile)
+    %                                    = db_set('FunctionalFile', FunctionalFile, FunctionalFileId)
     case 'FunctionalFile'
         % Minimum number of data (or matrix) files to create a datalist (or matrixlist)
+        % TODORC: How many items to create list?
         minListChildren = 2;
         list_names = [];
         % Default parameters

--- a/toolbox/db/db_set.m
+++ b/toolbox/db/db_set.m
@@ -11,7 +11,8 @@ function varargout = db_set(varargin)
 %    - sProtocol = db_set('Protocol', sProtocol, 1) : Insert current Protocol information
 %
 % ====== SUBJECTS ======================================================================
-%    - db_set('ParsedSubject', sParsedSubject)           : Insert or Update parsed subject, from db_parse_subject()
+%    - db_set('ParsedSubject', sParsedSubject)           : Insert parsed subject, from db_parse_subject()
+%    - db_set('ParsedSubject', sParsedSubject, iSubject) : Update parsed subject, from db_parse_subject()
 %    - db_set('Subject', 'Delete')                       : Delete all Subjects
 %    - db_set('Subject', 'Delete', SubjectId)            : Delete Subject by ID
 %    - db_set('Subject', 'Delete', CondQuery)            : Delete Subject with Query
@@ -107,9 +108,14 @@ switch contextName
 
 
 %% ==== PARSED SUBJECT ====
-    % iSubject = db_set('ParsedSubject', sParsedSubject)
+    % iSubject = db_set('ParsedSubject', sParsedSubject, iSubject)
     case 'ParsedSubject'
         sParsedSubject = varargin{2};  % sParsedSubjects is an array of old sSubject structure but iXxxx fields are be relative paths
+        iSubject = [];
+        if length(args) > 1
+            iSubject = varargin{3};
+        end
+
         % Default Anatomy and Surface files
         categories = strcat('i', {'Anatomy', 'Scalp', 'Cortex', 'InnerSkull', 'OuterSkull', 'Fibers', 'FEM'});
         fieldValPairs = [categories; cell(1,length(categories))];
@@ -121,8 +127,9 @@ switch contextName
         % Anatomy and Surface files
         sAnatFiles = [db_convert_anatomyfile(sParsedSubject.Anatomy, 'volume'), ...
                       db_convert_anatomyfile(sParsedSubject.Surface, 'surface')];
-        % Check if Subject already exists
-        sSubjectOld = db_get(sqlConn, 'Subject', struct('Name', sParsedSubject.Name, 'FileName', sParsedSubject.FileName), 'Id');
+        
+        % Check if Subject with index iSubject exists
+        sSubjectOld = db_get(sqlConn, 'Subject', iSubject, 'Id');
         if isempty(sSubjectOld)
             % Insert Subject
             iSubject = db_set(sqlConn, 'Subject', sParsedSubject);

--- a/toolbox/db/private/db_parse_subject.m
+++ b/toolbox/db/private/db_parse_subject.m
@@ -203,7 +203,7 @@ if ~isempty(subjMat)
     % ==== ANATOMY ====
     % By default : use the first anatomy in list (which is not a volume atlas)
     if ~isempty(sSubject(1).Anatomy)
-        sSubject(1).iAnatomy = 1;
+        sSubject(1).iAnatomy = sSubject(1).Anatomy(1).FileName;
     else
         sSubject(1).iAnatomy = [];
     end


### PR DESCRIPTION
* Add: `db_set` cases `ParsedSubject` and `ParsedStudy`
* Update: `bst_set` cases `ProtocolSubjects` and `Subject` to use `db_set(ParsedSubject)`
* Update: `bst_set` cases `ProtocolStudies` and `Study` to use `db_set(ParsedStudy)`
* Bugfix: `db_convert_*Files` can handle zero size input for Old>New conversion
* Bugfix: `db_get('StudiesFromSubject')`, one arg was ignored
* Add: `db_get(StudiesFromSubject)` can obtain @inter study if default subject
* Update: `db_links`, use new DB, do not regenerate entire study,, can also handle SQLite connection
* Update: `db_reload_database`, `db_load_subjects`, `db_load_studies` rely on `db_set` functions 
* Update: Reloading do not regenerate entire table (`db_reload_subjects`, `db_reload_studies`, `db_reload_conditions`)
* Bugfix: `db_parse_subject` iAnatomy was saved as `1` instead of path to default Anatomy