### PR TITLE
Sql treecallbacks

### DIFF
--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1429,7 +1429,7 @@ switch contextName
         warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
         
         iStudy = varargin{2};
-        sDataFuncFiles = db_get('DataForStudy', iStudy);
+        sDataFuncFiles = db_get('DataForStudy', iStudy, {'Id', 'Study'});
         argout1 = [sDataFuncFiles.Study];
         argout2 = [sDataFuncFiles.Id];
        
@@ -1441,7 +1441,7 @@ switch contextName
 
         iStudies = varargin{2};
         for i = 1:length(iStudies)
-            sDataFuncFiles = db_get('DataForStudy', iStudies(i));
+            sDataFuncFiles = db_get('DataForStudy', iStudies(i), {'Id', 'Study'});
             argout1 = [argout1, [sDataFuncFiles.Study]];
             argout2 = [argout2, [sDataFuncFiles.Id]];
         end

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -544,7 +544,7 @@ switch contextName
         argout1 = GlobalData.DataBase.(contextName)(argout2);
 
     case 'ProtocolSubjects'
-        warning('bst_get(\''%s'') is deprecated with the new Brainstorm database system.', contextName);
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'AllSubjects');
         argout1 = db_template('ProtocolSubjects');
         if GlobalData.DataBase.iProtocol == 0
             % No protocol loaded
@@ -578,7 +578,7 @@ switch contextName
         argout1.Subject = sSubjects;
         
     case 'ProtocolStudies'
-        warning('bst_get(\''%s'') is deprecated with the new Brainstorm database system.', contextName);
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'AllStudies');
         argout1 = db_template('ProtocolStudies');
         if GlobalData.DataBase.iProtocol == 0
             % No protocol loaded

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -934,6 +934,8 @@ switch contextName
 %% ==== ANALYSIS STUDY (INTER) ====
     % Usage: [sAnalStudyInter, iAnalStudyInter] = bst_get('AnalysisInterStudy') 
     case 'AnalysisInterStudy'
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'study');
+
         iAnalStudyInter = -2;
         [argout1, argout2] = bst_get('Study', iAnalStudyInter);
         

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1195,6 +1195,8 @@ switch contextName
 %% ==== CHANNEL FILE FOR STUDY ====
     % Usage: [ChannelFile, sStudy, iStudy] = bst_get('ChannelFileForStudy', StudyFile/DataFile)
     case 'ChannelFileForStudy'
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'ChannelFromStudy'' or ''ChannelFromFunctionalFile');
+
         % Parse inputs
         if (nargin == 2)
             StudyFile = varargin{2};
@@ -1207,12 +1209,12 @@ switch contextName
         isStudy = sql_query(sqlConn, 'EXIST', 'Study', struct('FileName', StudyFile));
         % If data file instead on Study file
         if ~isStudy
-            sFuncFile = db_get(sqlConn, 'FunctionalFile', StudyFile, 'Study');
+            [sChannel, sFuncFile] = db_get(sqlConn, 'ChannelFromFunctionalFile', StudyFile, '*', 'Study');
             if ~isempty(sFuncFile)
                 iStudy = sFuncFile.Study;
             end
         else
-            sStudy = db_get(sqlConn, 'Study', StudyFile, 'Id');
+            [sChannel, sStudy] = db_get(sqlConn, 'ChannelFromStudy', StudyFile, '*', 'Id');
             iStudy = sStudy.Id;
         end
         sql_close(sqlConn);
@@ -1221,7 +1223,6 @@ switch contextName
             return;
         end
         
-        sChannel = bst_get('ChannelForStudy', iStudy);
         if ~isempty(sChannel)
             argout1 = sChannel.FileName;
             if nargout > 1

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1248,11 +1248,10 @@ switch contextName
         for i = 1:length(iStudies)           
             % Get study 
             iStudy = iStudies(i);
-            [iChannel, iChanStudy] = db_get(sqlConn, 'ChannelFromStudy', iStudy);
-            sFuncFile = db_get(sqlConn, 'FunctionalFile', iChannel);
-            sChannel = db_convert_functionalfile(sFuncFile);
+            [sChannel, sChanStudy] = db_get(sqlConn, 'ChannelFromStudy', iStudy, '*', 'Id');
+            sChannel = db_convert_functionalfile(sChannel);
             if ~isempty(sChannel)
-                iChanStudies = [iChanStudies, iChanStudy];
+                iChanStudies = [iChanStudies, sChanStudy.Id];
                 sListChannel = [sListChannel, sChannel];
             end
         end

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1318,12 +1318,12 @@ switch contextName
         % Load sensor names from file
         TimefreqMat = in_bst_timefreq(TimefreqFile, 0, 'RowNames');
         % Get channel file
-        ChannelFile = bst_get('ChannelFileForStudy', TimefreqFile);
-        if isempty(ChannelFile)
+        sChannel = db_get('ChannelFromFunctionalFile', TimefreqFile, 'FileName');
+        if isempty(sChannel)
             return;
         end
         % Load channel file
-        ChannelMat = load(file_fullpath(ChannelFile), 'Channel');
+        ChannelMat = load(file_fullpath(sChannel.FileName), 'Channel');
         % Get channels that are present in the file
         [tmp__,I,J] = intersect({ChannelMat.Channel.Name}, TimefreqMat.RowNames);
         FileMod = unique({ChannelMat.Channel(I).Type});

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -621,6 +621,8 @@ switch contextName
     %        [sStudy, iStudy] = bst_get('Study')
     %        [sStudy, iStudy] = bst_get('Study', iStudies)
     case 'Study'
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
+
         if isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
             return;
         end
@@ -854,7 +856,7 @@ switch contextName
 %% ==== CHANNEL STUDIES WITH SUBJECT ====
     % Usage: iStudies = bst_get('ChannelStudiesWithSubject', iSubjects, 'NoIntra')
     case 'ChannelStudiesWithSubject'
-        warning('bst_set(''%s'') will be deprecated in new Brainstorm database system. Use db_set(''%s'')', contextName, contextName);
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
         % Parse inputs
         if (nargin >= 2) && isnumeric(varargin{2})
             iSubjects = varargin{2};
@@ -1066,7 +1068,7 @@ switch contextName
 %% ==== SURFACE FILE ====
     % Usage : [sSubject, iSubject, iSurface] = bst_get('SurfaceFile', SurfaceFile)
     case 'SurfaceFile'
-        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''SubjectFromAnatomyFile'')', contextName);
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get('''')', contextName, 'SubjectFromAnatomyFile');
         % No protocol in database
         if isempty(GlobalData) || isempty(GlobalData.DataBase) || isempty(GlobalData.DataBase.iProtocol) || (GlobalData.DataBase.iProtocol == 0)
             return;
@@ -1091,6 +1093,7 @@ switch contextName
     %         [sSurface, iSurface] = bst_get('SurfaceFileByType', MriFile,     SurfaceType)
     %         [sSurface, iSurface] = bst_get('SurfaceFileByType', ...,         SurfaceType, isDefaultOnly)
     case 'SurfaceFileByType'
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'AnatomyFilesWithSubject');
         % By default: return only the default surfaces of the category
         if (nargin < 4)
             isDefaultOnly = 1;

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1250,94 +1250,19 @@ switch contextName
     % Usage: [Modalities, DispMod, DefMod] = bst_get('ChannelModalities', ChannelFile)
     %        [Modalities, DispMod, DefMod] = bst_get('ChannelModalities', DataFile/ResultsFile/TimefreqFile...)
     case 'ChannelModalities'
-        % Get channel from input file
-        sqlConn = sql_connect();
-        sFuncFile = db_get(sqlConn, 'FunctionalFile', varargin{2}, {'Id', 'Study', 'Type'});
-        if strcmpi(sFuncFile.Type, 'channel')
-            sFuncFile = db_get(sqlConn, 'FunctionalFile', sFuncFile.Id);
-            sChannel = db_convert_functionalfile(sFuncFile);
-            sql_close(sqlConn);
-        else
-            sql_close(sqlConn);
-            sChannel = bst_get('ChannelForStudy', sFuncFile.Study);
-        end
-        % Return modalities
-        if ~isempty(sChannel)
-            % Get all modalities
-            if ~isempty(sChannel.DisplayableSensorTypes)
-                % Return the displayable sensors on top of the list
-                argout1 = cat(2, sChannel.DisplayableSensorTypes, setdiff(sChannel.Modalities, sChannel.DisplayableSensorTypes));
-            else
-                argout1 = sChannel.Modalities;
-            end
-            % Get only sensors that have spatial representation
-            argout2 = sChannel.DisplayableSensorTypes;
-            % Default candidates
-            if ~isempty(argout2)
-                defList = argout2;
-            else
-                defList = argout1;
-            end
-            if isempty(defList)
-                return;
-            end
-            % Remove EDF and BDF from the default list
-            defList = setdiff(defList, {'EDF','BDF','KDF'});
-            % Get default modality
-            if ismember('SEEG', defList)
-                argout3 = 'SEEG';
-            elseif ismember('ECOG', defList)
-                argout3 = 'ECOG';
-            elseif any(ismember({'MEG','MEG GRAD','MEG MAG'}, defList))
-                argout3 = 'MEG';
-            elseif ismember('EEG', defList)
-                argout3 = 'EEG';
-            elseif ismember('NIRS', defList)
-                argout3 = 'NIRS';
-            else
-                argout3 = defList{1};
-            end
-            % Place the default on top of the lists
-            if ismember(argout3, argout1)
-                argout1(strcmpi(argout1, argout3)) = [];
-                argout1 = cat(2, argout3, argout1);
-            end
-            if ismember(argout3, argout2)
-                argout2(strcmpi(argout2, argout3)) = [];
-                argout2 = cat(2, argout3, argout2);
-            end
-        else
-            argout1 = [];
-        end
-        
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
+
+        [argout1, argout2, argout3] = db_get('ChannelModalities', varargin{2});
+
 
 %% ==== TIMEFREQ DISPLAY MODALITIES ====
     % Usage: DisplayMod = bst_get('TimefreqDisplayModalities', TimefreqFile)
     case 'TimefreqDisplayModalities'
-        TimefreqFile = varargin{2};
-        % Load sensor names from file
-        TimefreqMat = in_bst_timefreq(TimefreqFile, 0, 'RowNames');
-        % Get channel file
-        sChannel = db_get('ChannelFromFunctionalFile', TimefreqFile, 'FileName');
-        if isempty(sChannel)
-            return;
-        end
-        % Load channel file
-        ChannelMat = load(file_fullpath(sChannel.FileName), 'Channel');
-        % Get channels that are present in the file
-        [tmp__,I,J] = intersect({ChannelMat.Channel.Name}, TimefreqMat.RowNames);
-        FileMod = unique({ChannelMat.Channel(I).Type});
-        % Check if only one type of gradiometer is selected
-        if isequal(FileMod, {'MEG GRAD'}) && all(cellfun(@(c)(c(end)=='2'), {ChannelMat.Channel(I).Name}))
-            argout1 = {'MEG GRAD2'};
-        elseif isequal(FileMod, {'MEG GRAD'}) && all(cellfun(@(c)(c(end)=='3'), {ChannelMat.Channel(I).Name}))
-            argout1 = {'MEG GRAD3'};
-        % Keep only the modalities that can be displayed (as topography)
-        else
-            argout1 = intersect(FileMod, {'MEG','MEG GRAD','MEG MAG','EEG','ECOG','SEEG','NIRS'});
-        end
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
         
-        
+        argout1 = db_get('TimefreqDisplayModalities', varargin{2});
+
+
 %% ==== CHANNEL DEVICE ====
     % Usage: Device = bst_get('ChannelDevice', ChannelFile)
     case 'ChannelDevice'

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -854,6 +854,7 @@ switch contextName
 %% ==== CHANNEL STUDIES WITH SUBJECT ====
     % Usage: iStudies = bst_get('ChannelStudiesWithSubject', iSubjects, 'NoIntra')
     case 'ChannelStudiesWithSubject'
+        warning('bst_set(''%s'') will be deprecated in new Brainstorm database system. Use db_set(''%s'')', contextName, contextName);
         % Parse inputs
         if (nargin >= 2) && isnumeric(varargin{2})
             iSubjects = varargin{2};
@@ -861,36 +862,12 @@ switch contextName
             error('Invalid call to bst_get()');
         end
         if (nargin == 3) && strcmpi(varargin{3}, 'NoIntra')
-            NoIntra = 1;
+            intra_str = '';
         else
-            NoIntra = 0;
+            intra_str = '@intra';
         end
-        % Process all subjects
-        iStudies = [];
-        sqlConn = sql_connect();
-        for i=1:length(iSubjects)
-            iSubject = iSubjects(i);
-            sSubject = db_get(sqlConn, 'Subject', iSubject, 'UseDefaultChannel');
-            % No subject: error
-            if isempty(sSubject) 
-                continue
-            % If subject uses default channel file    
-            elseif (sSubject.UseDefaultChannel ~= 0)
-                % Get default study for this subject
-                sStudy = db_get(sqlConn, 'DefaultStudy', iSubject, 'Id');
-                iStudies = [iStudies, sStudy.Id];
-            % Else: get all the studies belonging to this subject
-            else
-                if NoIntra
-                    sStudies = db_get(sqlConn, 'StudiesFromSubject', iSubject, 'Id');
-                else
-                    sStudies = db_get(sqlConn, 'StudiesFromSubject', iSubject, 'Id', '@intra');
-                end
-                iStudies = [iStudies, sStudies.Id];
-            end
-        end
-        sql_close(sqlConn);
-        argout1 = iStudies;
+        sStudies = db_get('ChannelStudiesWithSubject', iSubjects, 'Id', intra_str);
+        argout1 = [sStudies.Id];
     
         
 %% ==== STUDIES COUNT ====

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -891,26 +891,11 @@ switch contextName
         
 %% ==== NORMALIZED SUBJECT ====
     case 'NormalizedSubject'
-        % Get normalized subject name
-        normSubjName = 'Group_analysis';
-        % Try to get normalized subject
-        [sNormSubj, iNormSubj] = bst_get('Subject', normSubjName, 0);
-        % If normalized subject does not exist: create it
-        if isempty(sNormSubj)
-            % Always use default anatomy
-            UseDefaultAnat = 1;
-            % If all the subjects use a global channel file: Use global default as well
-            if ~isempty(GlobalData.DataBase.ProtocolSubjects(GlobalData.DataBase.iProtocol).Subject) && ...
-                all([GlobalData.DataBase.ProtocolSubjects(GlobalData.DataBase.iProtocol).Subject.UseDefaultChannel] == 2)
-                UseDefaultChannel = 2;
-            else
-                UseDefaultChannel = 1;
-            end    
-            % Create subject
-            [sNormSubj, iNormSubj] = db_add_subject(normSubjName, [], UseDefaultAnat, UseDefaultChannel);
-            % Get full subject structure
-            [sNormSubj, iNormSubj] = bst_get('Subject', normSubjName, 0);
-        end
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
+
+        sNormSubj = db_get('NormalizedSubject');
+        % Get full subject structure
+        [sNormSubj, iNormSubj] = bst_get('Subject', sNormSubj.Name, 0);
         argout1 = sNormSubj;
         argout2 = iNormSubj;
         

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1202,14 +1202,15 @@ switch contextName
         % Get study in database
         sqlConn = sql_connect();
         iStudy = [];
-        sStudy = db_get(sqlConn, 'Study', StudyFile, 'Id');
+        isStudy = sql_query(sqlConn, 'EXIST', 'Study', struct('FileName', StudyFile));
         % If data file instead on Study file
-        if isempty(sStudy)
+        if ~isStudy
             sFuncFile = db_get(sqlConn, 'FunctionalFile', StudyFile, 'Study');
             if ~isempty(sFuncFile)
                 iStudy = sFuncFile.Study;
             end
         else
+            sStudy = db_get(sqlConn, 'Study', StudyFile, 'Id');
             iStudy = sStudy.Id;
         end
         sql_close(sqlConn);

--- a/toolbox/core/bst_get.m
+++ b/toolbox/core/bst_get.m
@@ -1501,51 +1501,24 @@ switch contextName
 %% ==== DATA FOR STUDY (INCLUDING SHARED STUDIES) ====
     % Usage: [iStudies, iDatas] = bst_get('DataForStudy', iStudy)
     case 'DataForStudy'
-        % Get target study
-        iStudy = varargin{2};
-        sStudy = bst_get('Study', iStudy);
-        isDefaultStudy  = strcmpi(sStudy.Name, bst_get('DirDefaultStudy'));
-        isGlobalDefault = (iStudy == -3);
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, contextName);
         
-        % If study is the global default study
-        sStudies = [];
-        iStudies = [];
-        if isGlobalDefault
-            % Get all the subjects of the protocol
-            nbSubjects = bst_get('SubjectCount');
-            for iSubject = 1:nbSubjects
-                sSubject = bst_get('Subject', iSubject, 1);
-                if sSubject.UseDefaultChannel
-                    [tmp_sStudies, tmp_iStudies] = bst_get('StudyWithSubject', sSubject.FileName);
-                    sStudies = [sStudies, tmp_sStudies];
-                    iStudies = [iStudies, tmp_iStudies];
-                end
-            end
-        % Else, if study is a subject's default study (ie. channel file is shared by all studies of one subject)
-        elseif isDefaultStudy
-            % Get all the subject's studies
-            [sStudies, iStudies] = bst_get('StudyWithSubject', sStudy.BrainStormSubject, 'intra_subject', 'default_study');
-        else
-            % Normal: one channel per condition
-            sStudies = sStudy;
-            iStudies = iStudy;
-        end
-        % Get all the DataFiles for all these studies
-        for i = 1:length(sStudies)
-            nData = length(sStudies(i).Data);
-            argout1 = [argout1, repmat(iStudies(i), [1,nData])];
-            argout2   = [argout2, 1:nData];
-        end
+        iStudy = varargin{2};
+        sDataFuncFiles = db_get('DataForStudy', iStudy);
+        argout1 = [sDataFuncFiles.Study];
+        argout2 = [sDataFuncFiles.Id];
        
         
 %% ==== DATA FOR STUDIES (INCLUDING SHARED STUDIES) ====
     % Usage: [iStudies, iDatas] = bst_get('DataForStudies', iStudies)
     case 'DataForStudies'
+        warning('bst_get(''%s'') will be deprecated in new Brainstorm database system. Use db_get(''%s'')', contextName, 'DataForStudy');
+
         iStudies = varargin{2};
         for i = 1:length(iStudies)
-            [tmp_iStudies, tmp_iDatas] = bst_get('DataForStudy', iStudies(i));
-            argout1 = [argout1, tmp_iStudies];
-            argout2 = [argout2, tmp_iDatas];
+            sDataFuncFiles = db_get('DataForStudy', iStudies(i));
+            argout1 = [argout1, [sDataFuncFiles.Study]];
+            argout2 = [argout2, [sDataFuncFiles.Id]];
         end
         
 %% ==== DATA FILE FOR CHANNEL FILE ====

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -67,6 +67,9 @@ function varargout = db_get(varargin)
 %    - db_get('ChannelFromStudy', StudyID,       ChannelFields, StudyFields) : Find current Channel for StudyID
 %    - db_get('ChannelFromStudy', StudyFileName, ChannelFields, StudyFields) : Find current Channel for StudyFileName
 %    - db_get('ChannelFromStudy', CondQuery,     ChannelFields, StudyFields) : Find current Channel for Query struct
+%    - db_get('ChannelFromFunctionalFile', FunctFileID,       ChannelFields, FunctFileFields) : Find current Channel for FunctFileID
+%    - db_get('ChannelFromFunctionalFile', FunctFileFileName, ChannelFields, FunctFileFields) : Find current Channel for FunctFileFileName
+%    - db_get('ChannelFromFunctionalFile', CondQuery,         ChannelFields, FunctFileFields) : Find current Channel for Query struct
 %    - db_get('FilesInFileList', ListFileID, Fields)   : Get FunctionalFile belonging to a list with ID
 %    - db_get('FilesInFileList', ListFileName, Fields) : Get FunctionalFile belonging to a list with FileName
 %    - db_get('FilesInFileList', CondQuery, Fields)   : Get FunctionalFile belonging to a list with Query
@@ -646,6 +649,35 @@ switch contextName
                         varargout{2} = sStudy;
                     end
                 end
+            end
+        end
+
+
+%% ==== CHANNEL FROM FUNCTIONAL FILE ====
+    % [sChannel, sFunctFile] = db_get('ChannelFromFunctionalFile', FunctFileID,       ChannelFields, FunctFileFields)
+    %                        = db_get('ChannelFromFunctionalFile', FunctFileFileName, ChannelFields, FunctFileFields)
+    %                        = db_get('ChannelFromFunctionalFile', CondQuery,         ChannelFields, FunctFileFields)
+    case 'ChannelFromFunctionalFile'
+        iFuncFile = args{1};
+        channelFields = '*';
+        funcFields = '*';
+        if length(args) > 1 && ~isempty(args{2})
+            channelFields = args{2};
+            if length(args) > 2 && ~isempty(args{3})
+                funcFields = args{3};
+            end
+        end
+        varargout{1} = [];
+        varargout{2} = [];
+
+        sFuncFile = db_get(sqlConn, 'FunctionalFile', iFuncFile, 'Study');
+        sChannel =  db_get(sqlConn, 'ChannelFromStudy', sFuncFile.Study, channelFields);
+
+        if ~isempty(sChannel)
+            varargout{1} = sChannel;
+            if nargout > 1
+                sFuncFile = db_get(sqlConn, 'FunctionalFile', iFuncFile, funcFields);
+                varargout{2} = sFuncFile;
             end
         end
 

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -55,9 +55,6 @@ function varargout = db_get(varargin)
 %    - db_get('AllStudies', Fields)  : Get all Studies in current protocol, excluding @inter and global @default_study
 %    - db_get('AllStudies', Fields, '@inter', '@default_study')  : Get all Studies in current protocol including @inter and global @default_study
 %    - db_get('StudyWithCondition', ConditionPath, Fields) : Get studies for a given condition path
-%    - db_get('ChannelStudiesWithSubject', SubjectIDs) : Get all studies (except @intra) where there should be a channel file all iSubjects
-%    - db_get('ChannelStudiesWithSubject', SubjectIDs, Fields) : Get Fields of all studies (except @intra) where there should be a channel file all iSubjects
-%    - db_get('ChannelStudiesWithSubject', SubjectIDs. Fields, @intrac) : Get Fields all studies (including @intra) where there should be a channel file all iSubjects
 %
 % ====== FUNCTIONAL FILES ==============================================================
 %    - db_get('FunctionalFilesWithStudy', StudyID, FunctionalFileFields, FunctionalFileType, FunctionalFileSubtype, SubjectFields)       : Get FunctionalFiles for StudyID
@@ -83,6 +80,9 @@ function varargout = db_get(varargin)
 %    - db_get('DataForStudy', StudyId, DataFunctFileFields) : Get data FunctionalFiles for StudyID
 %    - db_get('DataForStudy', StudyId, DataFunctFileFields) : Get data FunctionalFiles for all Studies from same Subject (including @intra and @default_study) if StudyID is Subject's default study
 %    - db_get('DataForStudy', StudyId, DataFunctFileFields) : Get data FunctionalFiles for all Normal Studies of All Normal Subjects if StudyID is Global default study
+%    - db_get('ChannelStudiesWithSubject', SubjectIDs) : Get all studies (except @intra) where there should be a channel file all iSubjects
+%    - db_get('ChannelStudiesWithSubject', SubjectIDs, Fields) : Get Fields of all studies (except @intra) where there should be a channel file all iSubjects
+%    - db_get('ChannelStudiesWithSubject', SubjectIDs. Fields, @intrac) : Get Fields all studies (including @intra) where there should be a channel file all iSubjects
 %
 % ====== ANY FILE ======================================================================
 %    - db_get('AnyFile', FileName)         : Get any file by FileName

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -782,7 +782,7 @@ switch contextName
         end
 
 
-%% ==== CHANNEL MODALITIES =====
+%% ==== TIMEFREQ DISPLAY MODALITIES ====
     % DisplayMods = db_get('TimefreqDisplayModalities', FunctionalFileId)
     %             = db_get('TimefreqDisplayModalities', FunctionalFileFileName)
     case 'TimefreqDisplayModalities'

--- a/toolbox/db/db_get.m
+++ b/toolbox/db/db_get.m
@@ -1367,7 +1367,7 @@ switch contextName
         % Get all the DataFiles for all these studies
         sDataFunctFiles = [];
         for ix = 1:length(sStudies)
-            tmp_sDataFunctFiles = db_get(sqlConn, 'FunctionalFile', struct('Study', sStudies(ix).Id, 'Type', 'data'), '*', dataFuncFileFields);
+            tmp_sDataFunctFiles = db_get(sqlConn, 'FunctionalFile', struct('Study', sStudies(ix).Id, 'Type', 'data'), dataFuncFileFields);
             sDataFunctFiles = [sDataFunctFiles, tmp_sDataFunctFiles];
         end
         varargout{1} = sDataFunctFiles;

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -2711,7 +2711,7 @@ end % END SWITCH( ACTION )
                 end
             end
             % === OTHER SUBJECTS ===
-            if (bst_get('SubjectCount') > 1)
+            if (db_get('SubjectCount') > 1)
                 gui_component('MenuItem', jMenu, [], 'Other subjects...', IconLoader.ICON_SUBJECT, [], @(h,ev)ProjectSourcesAll(ResultFiles));
             end
         end
@@ -2724,7 +2724,7 @@ end % END SWITCH( ACTION )
             if ~isGroupAnalysis
                 gui_component('MenuItem', jPopup, [], 'Project source grid', IconLoader.ICON_ANATOMY, [], @(h,ev)bst_project_grid(ResultFiles, [], 1));
             % Default anatomy: Project back on subjects
-            elseif (bst_get('SubjectCount') > 1)
+            elseif (db_get('SubjectCount') > 1)
                 gui_component('MenuItem', jPopup, [], 'Project source grid...', IconLoader.ICON_ANATOMY, [], @(h,ev)ProjectGridAll(ResultFiles));
             end
         end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -661,7 +661,7 @@ switch (lower(action))
                 % Get subject
                 iStudy = bstNodes(1).getStudyIndex();
                 iSubject = bstNodes(1).getItemIndex();
-                sSubject = bst_get('Subject', iSubject);
+                sSubject = db_get('Subject', iSubject);
                 % If node is a directory node
                 isDirNode = (bstNodes(1).getStudyIndex() == 0);
                 % === EDIT SUBJECT ===

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1365,10 +1365,10 @@ switch (lower(action))
                         % Import in database
                         gui_component('MenuItem', jPopup, [], 'Import in database', IconLoader.ICON_EEG_NEW, [], @(h,ev)import_raw_to_db(filenameRelative));
                         % Load file descriptor
-                        ChannelFile = bst_get('ChannelFileForStudy', filenameRelative);
-                        if ~isempty(ChannelFile) && strcmpi(DataType, 'raw')
-                            Device = bst_get('ChannelDevice', ChannelFile);
-                            ChannelMat_Comment = in_bst_channel(ChannelFile,'Comment');
+                        sChannel = db_get('ChannelFromFunctionalFile', filenameRelative, 'FileName');
+                        if ~isempty(sChannel.FileName) && strcmpi(DataType, 'raw')
+                            Device = bst_get('ChannelDevice', sChannel.FileName);
+                            ChannelMat_Comment = in_bst_channel(sChannel.FileName,'Comment');
                             % If CTF file format
                             if strcmpi(Device, 'CTF') || ~isempty(strfind(ChannelMat_Comment.Comment, 'CTF'))
                                 gui_component('MenuItem', jPopup, [], 'Switch epoched/continous', IconLoader.ICON_RAW_DATA, [], @(h,ev)bst_process('CallProcess', 'process_ctf_convert', filenameFull, [], 'rectype', 3, 'interactive', 1));

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -713,7 +713,7 @@ switch (lower(action))
                     if (bstNodes(1).getStudyIndex() ~= 0) 
                         iStudy   = bstNodes(1).getStudyIndex();
                         iSubject = bstNodes(1).getItemIndex();
-                        sSubject = bst_get('Subject', iSubject);
+                        sSubject = db_get('Subject', iSubject);
                         % === IMPORT DATA/DIPOLES ===
                         if (length(bstNodes) == 1) && ~isRaw
                             gui_component('MenuItem', jPopup, [], 'Import MEG/EEG', IconLoader.ICON_EEG_NEW, [], @(h,ev)bst_call(@import_data, [], [], [], iStudy, iSubject));
@@ -769,9 +769,10 @@ switch (lower(action))
                         % Get all raw files contained in these folders
                         RawFiles = {};
                         for i = 1:length(bstNodes)
-                            sStudy = bst_get('Study', bstNodes(i).getStudyIndex());
-                            if ~isempty(sStudy) && (length(sStudy.Data) == 1) && strcmpi(sStudy.Data(1).DataType, 'raw')
-                                RawFiles{end+1} = sStudy.Data(1).FileName;
+                            sStudy = db_get('Study', bstNodes(i).getStudyIndex());
+                            sDataFiles = db_get('FunctionalFilesWithStudy', sStudy.Id, 'FileName', 'data', 'raw');
+                            if length(sDataFiles) == 1
+                                RawFiles{end+1} = sDataFiles(1).FileName;
                             end
                         end
                         jMenuExport = gui_component('MenuItem', [], [], 'Export to file', IconLoader.ICON_SAVE, [], @(h,ev)export_data(RawFiles));
@@ -783,15 +784,15 @@ switch (lower(action))
                 if ~bst_get('ReadOnly')
                     iStudy   = bstNodes(1).getStudyIndex();
                     iSubject = bstNodes(1).getItemIndex();
-                    sSubject = bst_get('Subject', iSubject);
+                    sSubject = db_get('Subject', iSubject);
                     % Get inter-subject study
-                    [sInterStudy, iInterStudy] = bst_get('AnalysisInterStudy');
+                    sInterStudy = db_get('Study', '@inter');
                     % === IMPORT DATA ===
                     if ~isSpecialNode
                         gui_component('MenuItem', jPopup, [], 'Import MEG/EEG', IconLoader.ICON_EEG_NEW, [], @(h,ev)bst_call(@import_data, [], [], [], iStudy, iSubject));
                     end
                     % If not Default Channel
-                    if (sSubject.UseDefaultChannel == 0) && (iStudy ~= iInterStudy)
+                    if (sSubject.UseDefaultChannel == 0) && (iStudy ~= sInterStudy.Id)
                         % === IMPORT CHANNEL / COMPUTE HEADMODEL ===
                         fcnPopupImportChannel(bstNodes, jPopup, 0);
                         fcnPopupMenuGoodBad();
@@ -833,8 +834,7 @@ switch (lower(action))
                 % Get study index
                 iStudy = bstNodes(1).getStudyIndex();
                 % Get subject structure
-                sStudy = bst_get('Study', iStudy);
-                sSubject = bst_get('Subject', sStudy.BrainStormSubject);
+                sSubject = db_get('SubjectFromStudy', iStudy);
                 % Get avaible modalities for this data file
                 [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
                 Device = bst_get('ChannelDevice', filenameRelative);
@@ -846,11 +846,7 @@ switch (lower(action))
                     end
                 end
                 % Find anatomy volumes (exclude atlases)
-                if ~isempty(sSubject.Anatomy)
-                    iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                else
-                    iVolAnat = [];
-                end
+                sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
                 % If only one modality
                 if (length(DisplayMod) == 1) && ((length(bstNodes) ~= 1) || isempty(Device)) && ~ismember(Device, {'Vectorview306', 'CTF', '4D', 'KIT', 'KRISS', 'BabyMEG', 'RICOH'}) && ~ismember(DisplayMod, {'EEG','ECOG','SEEG','ECOG+SEEG','NIRS'})
                     gui_component('MenuItem', jPopup, [], 'Display sensors', IconLoader.ICON_CHANNEL, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{1}, 'scalp'));
@@ -886,19 +882,19 @@ switch (lower(action))
                                 gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (Cortex)'],   IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{iType}, 'cortex', 1));
                             end
                             % MRI 3D
-                            if (length(iVolAnat) == 1)
-                                gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI 3D)'], IconLoader.ICON_ANATOMY, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{iType}, 'anatomy', iVolAnat(1)));
-                            elseif (length(iVolAnat) > 1)
-                                for iAnat = 1:length(iVolAnat)
-                                    gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI 3D: ' sSubject.Anatomy(iVolAnat(iAnat)).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{iType}, sSubject.Anatomy(iVolAnat(iAnat)).FileName, 1));
+                            if (length(sAnatFiles) == 1)
+                                gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI 3D)'], IconLoader.ICON_ANATOMY, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{iType}, 'anatomy', sAnatFiles.FileName));
+                            elseif (length(sAnatFiles) > 1)
+                                for iAnat = 1:length(sAnatFiles)
+                                    gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI 3D: ' sAnatFiles(iAnat).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)DisplayChannels(bstNodes, DisplayMod{iType}, sAnatFiles(iAnat).FileName, 1));
                                 end
                             end
                             % MRI Viewer
-                            if (length(iVolAnat) == 1)
-                                gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI Viewer)'], IconLoader.ICON_ANATOMY, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayMod{iType}, iVolAnat(1)));
-                            elseif (length(iVolAnat) > 1)
-                                for iAnat = 1:length(iVolAnat)
-                                    gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI Viewer: ' sSubject.Anatomy(iVolAnat(iAnat)).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayMod{iType}, iVolAnat(iAnat)));
+                            if (length(sAnatFiles) == 1)
+                                gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI Viewer)'], IconLoader.ICON_ANATOMY, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayMod{iType}, sAnatFiles.Id));
+                            elseif (length(sAnatFiles) > 1)
+                                for iAnat = 1:length(sAnatFiles)
+                                    gui_component('MenuItem', jMenuDisplay, [], [channelTypeDisplay '   (MRI Viewer: ' sAnatFiles(iAnat).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayMod{iType}, sAnatFiles(iAnat).Id));
                                 end
                             end
                         elseif ismember('NIRS', DisplayMod{iType})
@@ -961,20 +957,20 @@ switch (lower(action))
                                 if ~isempty(sSubject.iCortex)
                                     gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (Cortex)'],     IconLoader.ICON_ALIGN_CHANNELS, [], @(h,ev)channel_align_manual(filenameRelative, DisplayModReg{iMod}, 1, 'cortex'));
                                 end
-                                if (length(iVolAnat) == 1)
-                                    gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI 3D)'], IconLoader.ICON_ANATOMY, [], @(h,ev)channel_align_manual(filenameRelative, DisplayModReg{iMod}, 1, sSubject.Anatomy(iVolAnat(1)).FileName));
-                                elseif (length(iVolAnat) > 1)
-                                    for iAnat = 1:length(iVolAnat)
-                                        gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI 3D: ' sSubject.Anatomy(iVolAnat(iAnat)).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)channel_align_manual(filenameRelative, DisplayModReg{iMod}, 1, sSubject.Anatomy(iVolAnat(iAnat)).FileName));
+                                if (length(sAnatFiles) == 1)
+                                    gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI 3D)'], IconLoader.ICON_ANATOMY, [], @(h,ev)channel_align_manual(filenameRelative, DisplayModReg{iMod}, 1, sAnatFiles.FileName));
+                                elseif (length(sAnatFiles) > 1)
+                                    for iAnat = 1:length(sAnatFiles)
+                                        gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI 3D: ' sAnatFiles(iAnat).Comment ')'], IconLoader.ICON_ANATOMY, [], @(h,ev)channel_align_manual(filenameRelative, DisplayModReg{iMod}, 1, sAnatFiles(iAnat).FileName));
                                     end
                                 end
                             end
                             % Allow edition in MRI even if there is not location available for any electrode
-                            if (length(iVolAnat) == 1)
-                                gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI Viewer)'], IconLoader.ICON_ALIGN_CHANNELS, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayModReg{iMod}, iVolAnat(1)));
-                            elseif (length(iVolAnat) > 1)
-                                for iAnat = 1:length(iVolAnat)
-                                    gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI Viewer: ' sSubject.Anatomy(iVolAnat(iAnat)).Comment ')'], IconLoader.ICON_ALIGN_CHANNELS, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayModReg{iMod}, iVolAnat(iAnat)));
+                            if (length(sAnatFiles) == 1)
+                                gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI Viewer)'], IconLoader.ICON_ALIGN_CHANNELS, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayModReg{iMod}, sAnatFiles.Id));
+                            elseif (length(sAnatFiles) > 1)
+                                for iAnat = 1:length(sAnatFiles)
+                                    gui_component('MenuItem', jMenuAlign, [], [strType 'Edit...    (MRI Viewer: ' sAnatFiles(iAnat).Comment ')'], IconLoader.ICON_ALIGN_CHANNELS, [], @(h,ev)panel_ieeg('DisplayChannelsMri', filenameRelative, DisplayModReg{iMod}, sAnatFiles(iAnat).Id));
                                 end
                             end
                             AddSeparator(jMenuAlign);
@@ -1280,8 +1276,9 @@ switch (lower(action))
                 sStudy = bst_get('Study', iStudy);
                 iHeadModel = bstNodes(1).getItemIndex();
                 % Get channel file
-                if ~isempty(sStudy.Channel)
-                    ChannelFile = bst_fullfile(ProtocolInfo.STUDIES, sStudy.Channel.FileName);
+                if ~isempty(sStudy.iChannel)
+                    sChannel = db_get('FunctionalFile', sStudy.iChannel, 'FileName');
+                    ChannelFile = bst_fullfile(ProtocolInfo.STUDIES, sChannel.FileName);
                 else
                     ChannelFile = [];
                 end
@@ -1298,8 +1295,9 @@ switch (lower(action))
                     gui_component('MenuItem', jPopup, [], ['Set as default ' lower(nodeType)], IconLoader.ICON_GOOD, [], @(h,ev)SetDefaultHeadModel(bstNodes(1), iHeadModel, iStudy, sStudy));
                 end
                 % === CHECK SPHERES ===
-                MEGMethod = sStudy.HeadModel(iHeadModel).MEGMethod;
-                EEGMethod = sStudy.HeadModel(iHeadModel).EEGMethod;
+                sHeadModel = db_convert_functionalfile(db_get('FunctionalFile', iHeadModel));
+                MEGMethod = sHeadModel.MEGMethod;
+                EEGMethod = sHeadModel.EEGMethod;
                 isSepGain = 0;
                 if ~isempty(ChannelFile) && ((~isempty(MEGMethod) && ismember(MEGMethod, {'os_meg', 'meg_sphere', 'singlesphere', 'localspheres'})) || (~isempty(EEGMethod) && ismember(EEGMethod, {'eeg_3sphereberg', 'singlesphere', 'concentricspheres'})))
                     if ~bst_get('ReadOnly')
@@ -1307,18 +1305,18 @@ switch (lower(action))
                         AddSeparator(jPopup);
                     end
                     % Get subject
-                    [sSubject, iSubject] = bst_get('Subject', sStudy.BrainStormSubject);
+                    sSubject = db_get('Subject', sStudy.Subject);
                     gui_component('MenuItem', jPopup, [], 'Check spheres', IconLoader.ICON_HEADMODEL, [], @(h,ev)view_spheres(filenameFull, ChannelFile, sSubject));
                 end
                 
                 % === CHECK SOURCE GRID ===
-                if strcmpi(sStudy.HeadModel(iHeadModel).HeadModelType, 'volume') 
+                if strcmpi(sHeadModel.HeadModelType, 'volume')
                     if ~bst_get('ReadOnly') && ~isSepGain
                         AddSeparator(jPopup);
                     end
                     gui_component('MenuItem', jPopup, [], 'Check source grid (Cortex)', IconLoader.ICON_HEADMODEL, [], @(h,ev)view_gridloc(filenameFull));
                     gui_component('MenuItem', jPopup, [], 'Check source grid (MRI)', IconLoader.ICON_HEADMODEL, [], @(h,ev)view_gridloc(filenameFull, 'V', 'MRI'));
-                elseif strcmpi(sStudy.HeadModel(iHeadModel).HeadModelType, 'mixed')
+                elseif strcmpi(sHeadModel.HeadModelType, 'mixed')
                     if ~bst_get('ReadOnly') && ~isSepGain
                         AddSeparator(jPopup);
                     end
@@ -1342,10 +1340,9 @@ switch (lower(action))
                 iStudy = bstNodes(1).getStudyIndex();
                 iData = bstNodes(1).getItemIndex();
                 sFuncFile = db_get('FunctionalFile', iData);
-                sData = db_convert_functionalfile(sFuncFile);
                 sSubject = db_get('SubjectFromStudy', iStudy);
                 % Data type
-                DataType = sData.DataType;
+                DataType = sFuncFile.SubType;
                 isStat = ~strcmpi(DataType, 'recordings') && ~strcmpi(DataType, 'raw');
                 % Get modalities for first selected file
                 [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
@@ -1363,11 +1360,7 @@ switch (lower(action))
                     DisplayMod = cat(2, {'ECOG+SEEG'}, DisplayMod);
                 end
                 % Find anatomy volumes (exclude atlases)
-                if ~isempty(sSubject.Anatomy)
-                    iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                else
-                    iVolAnat = [];
-                end
+                sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
                 % One data file selected only
                 if (length(bstNodes) == 1)
                     % RAW continuous files
@@ -1416,24 +1409,26 @@ switch (lower(action))
                             % => ONLY for EEG, and if a scalp is defined
                             if strcmpi(AllMod{iMod}, 'EEG') && ~isempty(sSubject) && ~isempty(sSubject.iScalp) && ~isempty(DisplayMod) && ismember(AllMod{iMod}, DisplayMod)
                                 AddSeparator(jMenuModality);
-                                gui_component('MenuItem', jMenuModality, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iScalp).FileName, filenameRelative, AllMod{iMod}));
+                                sScalpDisp = db_get('AnatomyFile', sSubject.iScalp);
+                                gui_component('MenuItem', jMenuModality, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sScalpDisp.FileName, filenameRelative, AllMod{iMod}));
                             end
                             % === DISPLAY ON CORTEX/MRI ===
                             % => ONLY for SEEG/ECOG, and if a cortex/MRI is defined
                             if ismember(AllMod{iMod}, {'SEEG','ECOG','ECOG+SEEG'}) && ~isempty(sSubject) && ~isempty(DisplayMod) && ismember(AllMod{iMod}, DisplayMod)
                                 AddSeparator(jMenuModality);
                                 if ~isempty(sSubject.iCortex)
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iCortex).FileName, filenameRelative, AllMod{iMod}));
+                                    sCortexDisp = db_get('AnatomyFile', sSubject.iCortex);
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sCortexDisp.FileName, filenameRelative, AllMod{iMod}));
                                 end
-                                if (length(iVolAnat) == 1)
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, AllMod{iMod}));
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, AllMod{iMod}));
-                                elseif (length(iVolAnat) > 1)
-                                    for iAnat = 1:length(iVolAnat)
-                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, AllMod{iMod}));
+                                if (length(sAnatFiles) == 1)
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles.FileName, filenameRelative, AllMod{iMod}));
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles.FileName, filenameRelative, AllMod{iMod}));
+                                elseif (length(sAnatFiles) > 1)
+                                    for iAnat = 1:length(sAnatFiles)
+                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles(iAnat).FileName, filenameRelative, AllMod{iMod}));
                                     end
-                                    for iAnat = 1:length(iVolAnat)
-                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, AllMod{iMod}));
+                                    for iAnat = 1:length(sAnatFiles)
+                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles(iAnat).FileName, filenameRelative, AllMod{iMod}));
                                     end
                                 end
                             end
@@ -1541,14 +1536,13 @@ switch (lower(action))
             case 'pdata'
                 % Get protocol description
                 iStudy = bstNodes(1).getStudyIndex();
-                sStudy = bst_get('Study', iStudy);
+                % Get associated subject and surfaces, if it exists
+                sSubject = db_get('SubjectFromStudy', iStudy);
                 % Get avaible modalities for this data file
                 [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
                 % One data file selected only
                 if (length(bstNodes) == 1)
                     % === VIEW RESULTS ===
-                    % Get associated subject and surfaces, if it exists
-                    sSubject = bst_get('Subject', sStudy.BrainStormSubject);
                     % If channel file is defined and at least one modality
                     if ~isempty(AllMod)
                         % For each modality, display a menu
@@ -1574,13 +1568,15 @@ switch (lower(action))
                             % === DISPLAY ON SCALP ===
                             if strcmpi(AllMod{iMod}, 'EEG') && ~isempty(sSubject) && ~isempty(sSubject.iScalp) && ~isempty(DisplayMod) && ismember(AllMod{iMod}, DisplayMod)
                                 AddSeparator(jMenuModality);
-                                gui_component('MenuItem', jMenuModality, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iScalp).FileName, filenameRelative, AllMod{iMod}));
+                                sScalpDisp = db_get('AnatomyFile', sSubject.iScalp);
+                                gui_component('MenuItem', jMenuModality, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sScalpDisp.FileName, filenameRelative, AllMod{iMod}));
                             end
                             % === DISPLAY ON CORTEX ===
                             % => ONLY for SEEG/ECOG, and if a cortex is defined
                             if ismember(AllMod{iMod}, {'SEEG','ECOG','ECOG+SEEG'}) && ~isempty(sSubject) && ~isempty(sSubject.iCortex) && ~isempty(DisplayMod) && ismember(AllMod{iMod}, DisplayMod)
                                 AddSeparator(jMenuModality);
-                                gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iCortex).FileName, filenameRelative, AllMod{iMod}));
+                                sCortexDisp = db_get('AnatomyFile', sSubject.iCortex);
+                                gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sCortexDisp.FileName, filenameRelative, AllMod{iMod}));
                             end
                         end
                         
@@ -1640,11 +1636,10 @@ switch (lower(action))
 %% ===== POPUP: DATA LIST =====
             case 'datalist'                
                 if ~bst_get('ReadOnly')
-                    % Get protocol description
-                    iStudy = bstNodes(1).getStudyIndex();
-                    sStudy = bst_get('Study', iStudy);
+                    iList = bstNodes(1).getItemIndex();
+                    sChildren = db_get('ChildrenFromFunctionalFile', iList, 'FileName', 'data');
                     % Get avaible modalities for these data files
-                    [AllMod, DisplayMod] = bst_get('ChannelModalities', sStudy.Data(1).FileName);
+                    [AllMod, DisplayMod] = bst_get('ChannelModalities', sChildren(1).FileName);
                     if ~isempty(AllMod)
                         % === ERP IMAGE ===
                         jMenuErp = gui_component('Menu', jPopup, [], 'Display as image', IconLoader.ICON_NOISECOV, [], []);
@@ -1688,19 +1683,19 @@ switch (lower(action))
                 isLink = strcmpi(nodeType, 'link');
                 % Get study
                 iStudy = bstNodes(1).getStudyIndex();
-                sStudy = bst_get('Study', iStudy);
                 iResult = bstNodes(1).getItemIndex();
                 % Get associated subject
-                [sSubject, iSubject] = bst_get('Subject', sStudy.BrainStormSubject);
+                sSubject = db_get('SubjectFromStudy', iStudy);
                 % FOR FIRST NODE: Get associated recordings (DataFile)
-                DataFile = sStudy.Result(iResult).DataFile;
+                sResult = db_get('FunctionalFile', iResult);
+                DataFile = sResult.ExtraStr1; % DataFile;
                 isStat = ~isempty(strfind(filenameRelative, '_pthresh'));
                 % Get type of data node
                 isRaw = 0;
                 if ~isempty(DataFile)
-                    [tmp__, tmp__, iData] = bst_get('DataFile', DataFile, iStudy);
-                    if ~isempty(iData)
-                        isRaw = strcmpi(sStudy.Data(iData).DataType, 'raw');
+                    sData = db_get('FunctionalFile', DataFile, 'SubType');
+                    if ~isempty(sData)
+                        isRaw = strcmpi(sData.SubType, 'raw');
                     end
                 end
                 
@@ -1711,7 +1706,7 @@ switch (lower(action))
                 % ONE RESULTS FILE SELECTED
                 if (length(bstNodes) == 1)
                     % === DISPLAY ON CORTEX ===
-                    if ismember(sStudy.Result(iResult).HeadModelType, {'surface', 'mixed'})
+                    if ismember(sResult.ExtraStr2, {'surface', 'mixed'})
                         if ~isempty(sSubject) && ~isempty(sSubject.iCortex)
                             gui_component('MenuItem', jMenuActivations, [], 'Display on cortex', IconLoader.ICON_CORTEX, [], @(h,ev)view_surface_data([], filenameRelative));
                         else
@@ -1720,24 +1715,20 @@ switch (lower(action))
                     end
                     % === DISPLAY ON MRI ===
                     % Find anatomy volumes (exclude atlases)
-                    if ~isempty(sSubject.Anatomy)
-                        iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                    else
-                        iVolAnat = [];
-                    end
-                    if (length(iVolAnat) == 1)
-                        gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative));
-                        gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative));
-                    elseif (length(iVolAnat) > 1)
-                        for iAnat = 1:length(iVolAnat)
-                            gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (3D): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative));
+                    sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
+                    if (length(sAnatFiles) == 1)
+                        gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles.FileName, filenameRelative));
+                        gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles.FileName, filenameRelative));
+                    elseif (length(sAnatFiles) > 1)
+                        for iAnat = 1:length(sAnatFiles)
+                            gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (3D): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles(iAnat).FileName, filenameRelative));
                         end
-                        for iAnat = 1:length(iVolAnat)
-                            gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (MRI Viewer): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative));
+                        for iAnat = 1:length(sAnatFiles)
+                            gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (MRI Viewer): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles(iAnat).FileName, filenameRelative));
                         end
                     end
                     % === DISPLAY ON SPHERE ===
-                    if strcmpi(sStudy.Result(iResult).HeadModelType, 'surface') && ~isempty(sSubject) && ~isempty(sSubject.iCortex)
+                    if strcmpi(sResult.ExtraStr2, 'surface') && ~isempty(sSubject) && ~isempty(sSubject.iCortex)
                         AddSeparator(jMenuActivations);
                         gui_component('MenuItem', jMenuActivations, [], 'Display on spheres/squares', IconLoader.ICON_SURFACE, [], @(h,ev)view_surface_sphere(filenameRelative, 'orig'));
                         gui_component('MenuItem', jMenuActivations, [], '2D projection (Mollweide)', IconLoader.ICON_SURFACE, [], @(h,ev)view_surface_sphere(filenameRelative, 'mollweide'));
@@ -1748,8 +1739,8 @@ switch (lower(action))
                 fcnPopupScoutTimeSeries(jMenuActivations, 1);
 
                 % === MENU: SIMULATE DATA ===
-                [tmp__, iDefStudy]   = bst_get('DefaultStudy', iSubject);
-                if ~bst_get('ReadOnly') && ~isRaw && ~ismember(iStudy, iDefStudy) && ~isStat    % && ~isempty(strfind(filenameRelative, '_wMNE')) && ~strcmpi(sStudy.Result(iResult).HeadModelType, 'mixed')
+                sDefStudy = db_get('DefaultStudy', sSubject.Id, 'Id');
+                if ~bst_get('ReadOnly') && ~isRaw && ~ismember(iStudy, sDefStudy.Id) && ~isStat    % && ~isempty(strfind(filenameRelative, '_wMNE')) && ~strcmpi(sStudy.Result(iResult).HeadModelType, 'mixed')
                     jMenuModality = gui_component('Menu', jPopup, [], 'Model evaluation', IconLoader.ICON_RESULTS, [], []);
                     gui_component('MenuItem', jMenuModality, [], 'Simulate recordings', IconLoader.ICON_TS_DISPLAY, [], @(h,ev)bst_simulation(filenameRelative));
                     if ~isempty(DataFile)
@@ -1800,9 +1791,8 @@ switch (lower(action))
                 if (length(bstNodes) == 1)
                     % Get study
                     iStudy = bstNodes(1).getStudyIndex();
-                    sStudy = bst_get('Study', iStudy);
-                    % Get associated subject and surfaces, if it exists
-                    sSubject = bst_get('Subject', sStudy.BrainStormSubject);
+                    % Get associated subject
+                    sSubject = db_get('SubjectFromStudy', iStudy);
                     isVolumeGrid = ~isempty(strfind(filenameRelative, '_volume_'));
 
                     % === MENU: CORTICAL ACTIVATIONS ===
@@ -1813,20 +1803,16 @@ switch (lower(action))
                         end
                         % === DISPLAY ON MRI ===
                         % Find anatomy volumes (exclude atlases)
-                        if ~isempty(sSubject.Anatomy)
-                            iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                        else
-                            iVolAnat = [];
-                        end
-                        if (length(iVolAnat) == 1)
-                            gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative));
-                            gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative));
-                        elseif (length(iVolAnat) > 1)
-                            for iAnat = 1:length(iVolAnat)
-                                gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (3D): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative));
+                        sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
+                        if (length(sAnatFiles) == 1)
+                            gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles.FileName, filenameRelative));
+                            gui_component('MenuItem', jMenuActivations, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles.FileName, filenameRelative));
+                        elseif (length(sAnatFiles) > 1)
+                            for iAnat = 1:length(sAnatFiles)
+                                gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (3D): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles(iAnat).FileName, filenameRelative));
                             end
-                            for iAnat = 1:length(iVolAnat)
-                                gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (MRI Viewer): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative));
+                            for iAnat = 1:length(sAnatFiles)
+                                gui_component('MenuItem', jMenuActivations, [], ['Display on MRI (MRI Viewer): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles(iAnat).FileName, filenameRelative));
                             end
                         end
                     % === STAT CLUSTERS ===
@@ -1866,8 +1852,8 @@ switch (lower(action))
                 % Get study description
                 iStudy    = bstNodes(1).getStudyIndex();
                 iTimefreq = bstNodes(1).getItemIndex();
-                sStudy    = bst_get('Study', iStudy);
-                sSubject  = bst_get('Subject', sStudy.BrainStormSubject);
+                sSubject = db_get('SubjectFromStudy', iStudy);
+                sTimefreq = db_get('FunctionalFile', iTimefreq);
                 DisplayMod= {};
                 % Get data type
                 isStat = strcmpi(char(bstNodes(1).getType()), 'ptimefreq');
@@ -1880,16 +1866,16 @@ switch (lower(action))
                     end
                     DataFile = [];
                 else
-                    DataType = sStudy.Timefreq(iTimefreq).DataType;
-                    DataFile = sStudy.Timefreq(iTimefreq).DataFile;
+                    DataType = sTimefreq.SubType;   % DataType;
+                    DataFile = sTimefreq.ExtraStr1; % DataFile;
                 end
                 % Get source model
                 if strcmpi(DataType, 'results')
                     % Get head model type for the sources file
                     if ~isempty(DataFile)
-                        [sStudyData, iStudyData, iResult] = bst_get('AnyFile', DataFile);
-                        if ~isempty(sStudyData)
-                            isVolume = strcmpi(sStudyData.Result(iResult).HeadModelType, 'volume');
+                        sResult = db_get('FunctionalFile', DataFile);
+                        if ~isempty(sResult)
+                            isVolume = strcmpi(sResult.ExtraStr2, 'volume');
                         else
                             disp('BST> Error: This file was linked to a source file that was deleted.');
                             isVolume = 0;
@@ -1961,9 +1947,9 @@ switch (lower(action))
                                 end
                                 % MRI
                                 if isempty(strfind(filenameRelative, '_connectn')) && ~isempty(sSubject) && ~isempty(sSubject.iAnatomy)
-                                    MriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-                                    gui_component('MenuItem', jMenuConn1, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(MriFile, filenameRelative));
-                                    gui_component('MenuItem', jMenuConn1, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(MriFile, filenameRelative));
+                                    sAnatFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
+                                    gui_component('MenuItem', jMenuConn1, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative));
+                                    gui_component('MenuItem', jMenuConn1, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFile.FileName, filenameRelative));
                                 end
                             otherwise
                                 if ~isempty(strfind(filenameRelative, '_cohere')) || ~isempty(strfind(filenameRelative, '_spgranger')) || ~isempty(strfind(filenameRelative, '_henv')) || ~isempty(strfind(filenameRelative, '_pte')) ...
@@ -2010,9 +1996,9 @@ switch (lower(action))
                                     end
                                     % MRI
                                     if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy)
-                                        MriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(MriFile, filenameRelative));
-                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(MriFile, filenameRelative));
+                                        sAnatFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
+                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative));
+                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFile.FileName, filenameRelative));
                                     end
                                 otherwise
                             end
@@ -2062,9 +2048,9 @@ switch (lower(action))
                                     end
                                     % MRI
                                     if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy)
-                                        MriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(MriFile, filenameRelative));
-                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(MriFile, filenameRelative));
+                                        sAnatFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
+                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative));
+                                        gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFile.FileName, filenameRelative));
                                     end
                                 otherwise
                             end
@@ -2104,27 +2090,25 @@ switch (lower(action))
                                         AddSeparator(jPopup);
                                         % EEG: Display on scalp
                                         if strcmpi(DisplayMod{iMod}, 'EEG') && ~isempty(sSubject) && ~isempty(sSubject.iScalp)
-                                            gui_component('MenuItem', jPopup, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iScalp).FileName, filenameRelative, 'EEG'));
+                                            sAnatFile = db_get('AnatomyFile', sSubject.iScalp, 'FileName');
+                                            gui_component('MenuItem', jPopup, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative, 'EEG'));
                                         % SEEG/ECOG: Display on cortex or MRI
                                         elseif ismember(DisplayMod{iMod}, {'SEEG', 'ECOG', 'ECOG+SEEG'}) && ~isempty(sSubject)
                                             if ~isempty(sSubject.iCortex)
-                                                gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iCortex).FileName, filenameRelative, DisplayMod{iMod}));
+                                                sAnatFile = db_get('AnatomyFile', sSubject.iCortex, 'FileName');
+                                                gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative, DisplayMod{iMod}));
                                             end
                                             % Find anatomy volumes (exclude atlases)
-                                            if ~isempty(sSubject.Anatomy)
-                                                iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                                            else
-                                                iVolAnat = [];
-                                            end
-                                            if (length(iVolAnat) == 1)
-                                                gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, DisplayMod{iMod}));
-                                                gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, DisplayMod{iMod}));
-                                            elseif (length(iVolAnat) > 1)
-                                                for iAnat = 1:length(iVolAnat)
-                                                    gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, DisplayMod{iMod}));
+                                            sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
+                                            if (length(sAnatFiles) == 1)
+                                                gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles.FileName, filenameRelative, DisplayMod{iMod}));
+                                                gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles.FileName, filenameRelative, DisplayMod{iMod}));
+                                            elseif (length(sAnatFiles) > 1)
+                                                for iAnat = 1:length(sAnatFiles)
+                                                    gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles(iAnat).FileName, filenameRelative, DisplayMod{iMod}));
                                                 end
-                                                for iAnat = 1:length(iVolAnat)
-                                                    gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, DisplayMod{iMod}));
+                                                for iAnat = 1:length(sAnatFiles)
+                                                    gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles(iAnat).FileName, filenameRelative, DisplayMod{iMod}));
                                                 end
                                             end
                                         end
@@ -2140,9 +2124,9 @@ switch (lower(action))
                                 end
                                 % MRI
                                 if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy)
-                                    MriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-                                    gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(MriFile, filenameRelative));
-                                    gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(MriFile, filenameRelative));
+                                    sAnatFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
+                                    gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative));
+                                    gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFile.FileName, filenameRelative));
                                 end
                                 % MENU: EXPORT (Added later)
                                 jMenuExport{2} = gui_component('MenuItem', [], [], 'Export as 4D matrix', IconLoader.ICON_SAVE, [], @(h,ev)panel_process_select('ShowPanelForFile', {filenameFull}, 'process_export_spmvol'));
@@ -2186,9 +2170,8 @@ switch (lower(action))
                 % Get study description
                 iStudy = bstNodes(1).getStudyIndex();
                 iTimefreq = bstNodes(1).getItemIndex();
-                sStudy = bst_get('Study', iStudy);
-                % Get subject structure
-                sSubject = bst_get('Subject', sStudy.BrainStormSubject);
+                sSubject = db_get('SubjectFromStudy', iStudy);
+                sTimefreq = db_get('FunctionalFile', iTimefreq);
                 % Get data type
                 if strcmpi(nodeType, 'pspectrum')
                     TimefreqMat = in_bst_timefreq(filenameRelative, 0, 'DataType');
@@ -2199,8 +2182,8 @@ switch (lower(action))
                     end
                     DataFile = [];
                 else
-                    DataType = sStudy.Timefreq(iTimefreq).DataType;
-                    DataFile = sStudy.Timefreq(iTimefreq).DataFile;
+                    DataType = sTimefreq.SubType;   % DataType;
+                    DataFile = sTimefreq.ExtraStr1; % DataFile;
                 end
                 % One file selected
                 if (length(bstNodes) == 1)
@@ -2235,27 +2218,25 @@ switch (lower(action))
                             AddSeparator(jPopup);
                             % EEG: Display on scalp
                             if strcmpi(DisplayMod{iMod}, 'EEG') && ~isempty(sSubject) && ~isempty(sSubject.iScalp)
-                                gui_component('MenuItem', jPopup, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iScalp).FileName, filenameRelative, 'EEG'));
+                                sAnatFile = db_get('AnatomyFile', sSubject.iScalp, 'FileName');
+                                gui_component('MenuItem', jPopup, [], 'Display on scalp', IconLoader.ICON_SURFACE_SCALP, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative, 'EEG'));
                             % SEEG/ECOG: Display on cortex or MRI
                             elseif ismember(DisplayMod{iMod}, {'SEEG', 'ECOG', 'ECOG+SEEG'}) && ~isempty(sSubject)
                                 if ~isempty(sSubject.iCortex)
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sSubject.Surface(sSubject.iCortex).FileName, filenameRelative, DisplayMod{iMod}));
+                                    sAnatFile = db_get('AnatomyFile', sSubject.iCortex, 'FileName');
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on cortex', IconLoader.ICON_SURFACE_CORTEX, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative, DisplayMod{iMod}));
                                 end
                                 % Find anatomy volumes (exclude atlases)
-                                if ~isempty(sSubject.Anatomy)
-                                    iVolAnat = find(cellfun(@(c)isempty(strfind(c, '_volatlas')), {sSubject.Anatomy.FileName}));
-                                else
-                                    iVolAnat = [];
-                                end
-                                if (length(iVolAnat) == 1)
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, DisplayMod{iMod}));
-                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(1)).FileName, filenameRelative, DisplayMod{iMod}));
-                                elseif (length(iVolAnat) > 1)
-                                    for iAnat = 1:length(iVolAnat)
-                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, DisplayMod{iMod}));
+                                sAnatFiles = db_get('AnatomyFilesWithSubject', sSubject.Id, '*', 'Volume', 'Image');
+                                if (length(sAnatFiles) == 1)
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles.FileName, filenameRelative, DisplayMod{iMod}));
+                                    gui_component('MenuItem', jMenuModality, [], 'Display on MRI (3D)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles.FileName, filenameRelative, DisplayMod{iMod}));
+                                elseif (length(sAnatFiles) > 1)
+                                    for iAnat = 1:length(sAnatFiles)
+                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (MRI Viewer): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFiles(iAnat).FileName, filenameRelative, DisplayMod{iMod}));
                                     end
-                                    for iAnat = 1:length(iVolAnat)
-                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sSubject.Anatomy(iVolAnat(iAnat)).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sSubject.Anatomy(iVolAnat(iAnat)).FileName, filenameRelative, DisplayMod{iMod}));
+                                    for iAnat = 1:length(sAnatFiles)
+                                        gui_component('MenuItem', jMenuModality, [], ['Display on MRI (3D): ' sAnatFiles(iAnat).Comment], IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFiles(iAnat).FileName, filenameRelative, DisplayMod{iMod}));
                                     end
                                 end
                             end
@@ -2266,8 +2247,8 @@ switch (lower(action))
                         AddSeparator(jPopup);
                         % Get head model type for the sources file
                         if ~isempty(DataFile)
-                            [sStudyData, iStudyData, iResult] = bst_get('AnyFile', DataFile);
-                            isVolume = strcmpi(sStudyData.Result(iResult).HeadModelType, 'volume');
+                            sResults = db_get('FunctionalFile', DataFile);
+                            isVolume = strcmpi(sResults.ExtraStr2, 'volume');
                         % Get the default head model
                         else
                             wloc    = whos('-file', filenameFull, 'GridLoc');
@@ -2279,9 +2260,9 @@ switch (lower(action))
                             gui_component('MenuItem', jPopup, [], 'Display on cortex', IconLoader.ICON_CORTEX, [], @(h,ev)view_surface_data([], filenameRelative));
                         end
                         if ~isempty(sSubject) && ~isempty(sSubject.iAnatomy)
-                            MriFile = sSubject.Anatomy(sSubject.iAnatomy).FileName;
-                            gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(MriFile, filenameRelative));
-                            gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(MriFile, filenameRelative));
+                            sAnatFile = db_get('AnatomyFile', sSubject.iAnatomy, 'FileName');
+                            gui_component('MenuItem', jPopup, [], 'Display on MRI   (3D)',         IconLoader.ICON_ANATOMY, [], @(h,ev)view_surface_data(sAnatFile.FileName, filenameRelative));
+                            gui_component('MenuItem', jPopup, [], 'Display on MRI   (MRI Viewer)', IconLoader.ICON_ANATOMY, [], @(h,ev)view_mri(sAnatFile.FileName, filenameRelative));
                         end
                         % MENU: EXPORT (Added later)
                         if strcmpi(nodeType, 'spectrum')
@@ -2420,14 +2401,12 @@ switch (lower(action))
             if strcmpi(nodeType, 'rawdata') && isone
                 RawFile = filenameRelative;
             elseif (isstudy && strcmpi(nodeType, 'rawcondition')) && isone
-                % Get study
-                sStudy = bst_get('Study', iStudy);
                 % Find raw data file in the condition
-                iDataRaw = find(strcmpi({sStudy.Data.DataType}, 'raw'));
-                if isempty(iDataRaw)
+                sDataRaw = db_get('FunctionalFilesWithStudy', iStudy, 'FileName', 'Data', 'raw');
+                if isempty(sDataRaw)
                     RawFile = [];
                 else
-                    RawFile = sStudy.Data(iDataRaw(1)).FileName;
+                    RawFile = sDataRaw(1).FileName;
                 end
             else
                 RawFile = [];

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -3678,10 +3678,10 @@ function ImportChannelCheck(iAllStudies)
     % Check only if importing a single file
     if (length(iAllStudies) == 1)
         % Get study folder
-        sStudyChan = bst_get('Study', iAllStudies(1));
-        sStudyData = bst_get('DataForStudy', iAllStudies(1));
+        sChannel = db_get('FunctionalFileWithStudy', iAllStudies(1), 'FileName', 'Channel');
+        sDatas = db_get('DataForStudy', iAllStudies(1));
         % If there is already a channel file defined
-        if ~isempty(sStudyChan.Channel) && ~isempty(sStudyChan.Channel.FileName) && ~isempty(sStudyData)
+        if ~isempty(sChannel) && ~isempty(sChannel.FileName) && ~isempty(sDatas)
             res = java_dialog('confirm', [...
                 '<HTML><B>Warning</B>: There are existing channel files and data files in this folder.<BR>', ...
                 'Importing a list of channels that does not match exactly the recordings<BR>' ...

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -1513,10 +1513,10 @@ switch (lower(action))
                 % INVERSE SOLUTIONS
                 if ~bst_get('ReadOnly') && ~isempty(AllMod) && ismember(DataType, {'raw', 'recordings'})
                     % Get subject and inter-subject study
-                    [sInterStudy, iInterStudy] = bst_get('AnalysisInterStudy');
+                    sInterStudy =  db_get('Study', '@inter', 'Id');
                     % === COMPUTE SOURCES ===
                     % If not Default Channel
-                    if (sSubject.UseDefaultChannel == 0) && (isempty(iInterStudy) || iStudy ~= iInterStudy)
+                    if (sSubject.UseDefaultChannel == 0) && (isempty(sInterStudy.Id) || iStudy ~= sInterStudy.Id)
                         fcnPopupComputeHeadmodel();
                     else
                         AddSeparator(jPopup);    

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -3613,7 +3613,7 @@ end
 %% ===== NEW GROUP ANALYSIS =====
 function NewGroupAnalysis()
     % Create/get group analysis subject
-    [sSubject, iSubject] = bst_get('NormalizedSubject');
+    db_get('NormalizedSubject');
     % Update tree
     panel_protocols('UpdateTree');
 end

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -236,7 +236,7 @@ switch (lower(action))
             % Else : Edit channel file
             case 'channel'
                 % Get displayable modalities for this file
-                [tmp, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
+                [tmp, DisplayMod] = db_get('ChannelModalities', filenameRelative);
                 DisplayMod = intersect(DisplayMod, {'EEG','MEG','MEG GRAD','MEG MAG','ECOG','SEEG','ECOG+SEEG','NIRS'});
                 % If only one modality
                 if ~isempty(DisplayMod)
@@ -835,7 +835,7 @@ switch (lower(action))
                 % Get subject structure
                 sSubject = db_get('SubjectFromStudy', iStudy);
                 % Get avaible modalities for this data file
-                [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
+                [AllMod, DisplayMod] = db_get('ChannelModalities', filenameRelative);
                 Device = bst_get('ChannelDevice', filenameRelative);
                 % Replace SEEG+ECOG with iEEG
                 if ~isempty(AllMod) && all(ismember({'SEEG','ECOG'}, AllMod))
@@ -1242,7 +1242,7 @@ switch (lower(action))
             case {'noisecov', 'ndatacov'}
                 if (length(bstNodes) == 1)
                     % Get modalities for first selected file
-                    AllMod = intersect(bst_get('ChannelModalities', filenameRelative), {'MEG', 'MEG MAG', 'MEG GRAD', 'EEG', 'SEEG', 'ECOG'});
+                    AllMod = intersect(db_get('ChannelModalities', filenameRelative), {'MEG', 'MEG MAG', 'MEG GRAD', 'EEG', 'SEEG', 'ECOG'});
                     % Display as image
                     if (length(AllMod) == 1)
                         gui_component('MenuItem', jPopup, [], 'Display as image', IconLoader.ICON_NOISECOV, [], @(h,ev)view_noisecov(filenameRelative));
@@ -1342,7 +1342,7 @@ switch (lower(action))
                 DataType = sFuncFile.SubType;
                 isStat = ~strcmpi(DataType, 'recordings') && ~strcmpi(DataType, 'raw');
                 % Get modalities for first selected file
-                [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
+                [AllMod, DisplayMod] = db_get('ChannelModalities', filenameRelative);
                 % Remove EDF Annotation channels from the list
                 % iEDF = find(strcmpi(AllMod, 'EDF') | strcmpi(AllMod, 'BDF'));
                 iEDF = find(strcmpi(AllMod, 'EDF'));
@@ -1536,7 +1536,7 @@ switch (lower(action))
                 % Get associated subject and surfaces, if it exists
                 sSubject = db_get('SubjectFromStudy', iStudy);
                 % Get avaible modalities for this data file
-                [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
+                [AllMod, DisplayMod] = db_get('ChannelModalities', filenameRelative);
                 % One data file selected only
                 if (length(bstNodes) == 1)
                     % === VIEW RESULTS ===
@@ -1636,7 +1636,7 @@ switch (lower(action))
                     iList = bstNodes(1).getItemIndex();
                     sChildren = db_get('ChildrenFromFunctionalFile', iList, 'FileName', 'data');
                     % Get avaible modalities for these data files
-                    [AllMod, DisplayMod] = bst_get('ChannelModalities', sChildren(1).FileName);
+                    [AllMod, DisplayMod] = db_get('ChannelModalities', sChildren(1).FileName);
                     if ~isempty(AllMod)
                         % === ERP IMAGE ===
                         jMenuErp = gui_component('Menu', jPopup, [], 'Display as image', IconLoader.ICON_NOISECOV, [], []);
@@ -1885,7 +1885,7 @@ switch (lower(action))
                     end
                 % Get available modalities for this data file
                 elseif strcmpi(DataType, 'data')
-                    DisplayMod = bst_get('TimefreqDisplayModalities', filenameRelative);
+                    DisplayMod = db_get('TimefreqDisplayModalities', filenameRelative);
                     % Add SEEG+ECOG 
                     if ~isempty(DisplayMod) && all(ismember({'SEEG','ECOG'}, DisplayMod))
                         DisplayMod = cat(2, {'ECOG+SEEG'}, DisplayMod);
@@ -2187,7 +2187,7 @@ switch (lower(action))
                     % ===== RECORDINGS =====
                     if strcmpi(DataType, 'data')
                         % Get avaible modalities for this data file
-                        DisplayMod = bst_get('TimefreqDisplayModalities', filenameRelative);
+                        DisplayMod = db_get('TimefreqDisplayModalities', filenameRelative);
                         % Add SEEG+ECOG 
                         if all(ismember({'SEEG','ECOG'}, DisplayMod))
                             DisplayMod = cat(2, {'ECOG+SEEG'}, DisplayMod);

--- a/toolbox/tree/tree_channel_studies.m
+++ b/toolbox/tree/tree_channel_studies.m
@@ -53,7 +53,7 @@ for iNode = 1:length(bstNodes)
                 return
             end
             % Get the channel studies for all the subjects of the protocol
-            iStudies = addAllSubjectsStudies(sqlConn, sqlConniStudies, [sSubjects.Id], NoIntra);
+            iStudies = addAllSubjectsStudies(sqlConn, iStudies, [sSubjects.Id], NoIntra);
             
         % ==== SUBJECT ====
         case 'studysubject'

--- a/toolbox/tree/tree_channel_studies.m
+++ b/toolbox/tree/tree_channel_studies.m
@@ -137,9 +137,9 @@ end
 iStudies = unique(iStudies);
 iChanStudies = [];
 for i = 1:length(iStudies)
-    [sChannels, iChanStudy] = db_get(sqlConn, 'ChannelFromStudy', iStudies(i));
-    if ~isempty(iChanStudy)
-        iChanStudies(end + 1) = iChanStudy;
+    [sChannels, sChanStudy] = db_get(sqlConn, 'ChannelFromStudy', iStudies(i), 'Id', 'Id');
+    if ~isempty(sChanStudy)
+        iChanStudies(end + 1) = sChanStudy.Id;
     end
 end
 iStudies = unique(iChanStudies);

--- a/toolbox/tree/tree_dependencies.m
+++ b/toolbox/tree/tree_dependencies.m
@@ -590,10 +590,15 @@ if ~isempty(iTargetStudies)
                         iValidResult = ~isPureKernel(sFuncFiles);
                     end
                     % Remove bad trials
-                    for iRes = 1:length(iValidResult)
-                        if iValidResult(iRes)
-                            sFuncFileData = db_get(sqlConn, 'ParentFromFunctionalFile', ResultsIds(iRes), 'ExtraNum');
-                            iValidResult(iRes) = ~sFuncFileData.ExtraNum;
+                    if ~GetBadTrials
+                        for iRes = 1:length(iValidResult)
+                            if iValidResult(iRes)
+                                % Search for Data parent
+                                sFuncFileData = db_get(sqlConn, 'ParentFromFunctionalFile', ResultsIds(iRes), 'ExtraNum');
+                                if ~isempty(sFuncFileData)
+                                    iValidResult(iRes) = ~sFuncFileData.ExtraNum;
+                                end
+                            end
                         end
                     end
                     % Return selected files


### PR DESCRIPTION
- Update `tree_callback` to work with SQLite DB:
- Single SQLite connection for `tree_channel_studies`
- Add following cases to `db_get`
  - 'NormalizedSubject'
  - 'ChannelFromStudy'  
  - 'ChannelFromFunctionalFile'
  - 'DataForStudy'
  - 'ChannelStudiesWithSubject'
  - 'ChannelModalities'
  - 'TimefreqDisplayModalities'

- The following cases from `bst_get` are written as `db_get` wrappers with deprecation warnings:
  - 'NormalizedSubject'
  - 'ChannelStudiesWithSubject'
  - 'ChannelFileForStudy'
  - 'ChannelModalities'
  - 'TimefreqDisplayModalities'
  - 'DataForStudy'

- Add deprecation warnings where needed in `bst_get` cases
- Bugfix: `tree_dependencies`