### PR TITLE
Thresholding of isosurface without creating a new one

### DIFF
--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -163,7 +163,9 @@ if isSave
     MeshFile  = bst_fullfile(SurfaceDir, 'tess_isosurface.mat');
     % Get isoSurface (tess_isosurface.mat)
     [~, ~, iSurface] = bst_get('SurfaceFile', MeshFile);
-    
+    % Get 3D figure window
+    hFig = bst_figures('GetFiguresByType', '3DViz');
+
     sMesh.FileName = file_short(MeshFile);
     sMesh.Name = 'Other';
     % if isosurface not created create it 
@@ -172,14 +174,18 @@ if isSave
         bst_save(MeshFile, sMesh, 'v7');
         iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
         MriFile = sSubject.Anatomy(1).FileName;
-        hFig = bst_figures('GetFiguresByType', '3DViz');
         if isempty(hFig)
             hFig = view_mri_3d(MriFile, [], 0.3, []);
         end
         view_surface(MeshFile, [], [], hFig, []);
-    else % else just update the isosurface surface patch with new computed values
+    else % else just update the isosurface surface patch with new computed values    
+        % if surface present in database but figure not opened, open it 
+        if isempty(hFig)
+            MriFile = sSubject.Anatomy(1).FileName;
+            hFig = view_mri_3d(MriFile, [], 0.3, []);
+            view_surface(MeshFile, [], [], hFig, []);
+        end
         % update the surface displayed in figure 
-        hFig = bst_figures('GetFiguresByType', '3DViz');
         TessInfo = getappdata(hFig, 'Surface');
         iSurfPatch = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {TessInfo.SurfaceFile}));
         set(TessInfo(iSurfPatch).hPatch, 'Vertices', sMesh.Vertices);

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -178,7 +178,7 @@ if isSave
         % update the surface displayed in figure 
         hFig = bst_figures('GetFiguresByType', '3DViz');
         TessInfo = getappdata(hFig, 'Surface');
-        iSurfPatch = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
+        iSurfPatch = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {TessInfo.SurfaceFile}));
         set(TessInfo(iSurfPatch).hPatch, 'Vertices', sMesh.Vertices);
         set(TessInfo(iSurfPatch).hPatch, 'Faces', sMesh.Faces);
         set(TessInfo(iSurfPatch).hPatch, 'FaceVertexCData', ones(size(sMesh.Vertices)));

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -149,6 +149,9 @@ sMesh.Vertices = bst_bsxfun(@times, sMesh.Vertices, sMri.Voxsize);
 sMesh.Vertices = cs_convert(sMri, 'mri', 'scs', sMesh.Vertices ./ 1000);
 sMesh.Comment = sprintf('isoSurface (ISO_%d)', isoValue);
 sMesh.VertConn = tess_vertconn(sMesh.Vertices, sMesh.Faces);
+sMesh.VertNormals = tess_normals(sMesh.Vertices, sMesh.Faces, sMesh.VertConn);
+[~, sMesh.VertArea] = tess_area(sMesh.Vertices, sMesh.Faces);
+sMesh.SulciMap = tess_sulcimap(sMesh);
 
 %% ===== SAVE FILES =====
 if isSave
@@ -165,7 +168,7 @@ if isSave
     sMesh.Name = 'Other';
     % if isosurface not created create it 
     if isempty(iSurface)    
-        sMesh = bst_history('add', sMesh, 'threshold_ct', 'CT thresholded isosurface generated with Brainstorm');
+        sMesh = bst_history('add', sMesh, 'threshold_ct', ['CT isosurface generated with isoValue threshold ' num2str(isoValue)]);
         bst_save(MeshFile, sMesh, 'v7');
         iSurface = db_add_surface(iSubject, MeshFile, sMesh.Comment);
         MriFile = sSubject.Anatomy(1).FileName;
@@ -189,7 +192,8 @@ if isSave
         iSurfGlobal = find(file_compare({GlobalData.Surface.FileName}, sMesh.FileName));
         GlobalData.Surface(iSurfGlobal) = sMesh;
         % update the surface in tess_isosurface.mat 
-        sMesh = bst_history('add', sMesh, 'threshold_ct', 'CT thresholded isosurface updated');
+        sMesh = bst_history('add', sMesh, 'threshold_ct', ['CT isosurface updated with isovalue threshold ' num2str(isoValue)]);
+        sMesh.Curvature   = tess_curvature(sMesh.Vertices, sMesh.VertConn, sMesh.VertNormals, .1);
         bst_save(MeshFile, sMesh, 'v7');
         % reload the subject to reflect updated values 
         db_reload_subjects(iSubject);

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -171,10 +171,12 @@ if isSave
         view_surface(MeshFile, [], [], hFig, []);
         panel_surface('SetIsoValue', isoValue);
     else % else just update the isosurface surface patch with new computed values
+        % update the data file with new mesh data in database
         sMesh = bst_history('add', sMesh, 'threshold_ct', 'CT thresholded isosurface updated');
         bst_save(MeshFile, sMesh, 'v7');
+        % reload the subject to reflect updated values 
         db_reload_subjects(iSubject);
-
+        % update the surface displayed in figure 
         hFig = bst_figures('GetFiguresByType', '3DViz');
         TessInfo = getappdata(hFig, 'Surface');
         iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));

--- a/toolbox/anatomy/tess_isosurface.m
+++ b/toolbox/anatomy/tess_isosurface.m
@@ -169,7 +169,6 @@ if isSave
             hFig = view_mri_3d(MriFile, [], 0.3, []);
         end
         view_surface(MeshFile, [], [], hFig, []);
-        panel_surface('SetIsoValue', isoValue);
     else % else just update the isosurface surface patch with new computed values
         % update the data file with new mesh data in database
         sMesh = bst_history('add', sMesh, 'threshold_ct', 'CT thresholded isosurface updated');

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1664,6 +1664,36 @@ function DisplayFigurePopup(hFig)
         end
         jPopup.addSeparator();
     end
+    
+    % ==== MENU: ISOSURFACE ====
+    % Create isosurface
+    iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
+    if ~isempty(iSurf)
+        % get the CT file details
+        SubjectFile = getappdata(hFig, 'SubjectFile');
+        sSubject = bst_get('Subject', SubjectFile);
+        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+        CtFile = sSubject.Anatomy(iCt(1)).FileName;
+        sCt = bst_memory('LoadMri', CtFile);
+        % panel operations
+        jPanel = gui_component('Panel');
+        jPanel.setOpaque(0);
+        jPopup.add(jPanel);
+        % Title
+        jLabel = gui_component('label', [], '', '<HTML><B>isoValue </B>', IconLoader.ICON_SURFACE);
+        jPanel.add(jLabel, BorderLayout.WEST);
+        % Spin button
+        sSurface = bst_memory('LoadSurface', TessInfo(iSurf).SurfaceFile);
+        val = regexp(sSurface.Comment, '\d+', 'match');
+        spinmodel = SpinnerNumberModel(str2double(val(1)), double(sCt.Histogram.whiteLevel), double(sCt.Histogram.intensityMax), 50);
+        jSpinner = JSpinner(spinmodel);
+        jSpinner.setPreferredSize(Dimension(55,25));
+        % jSpinner.setToolTipText(strTooltip);
+        jPanel.add(jSpinner, BorderLayout.CENTER);
+        jButtonSet = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
+        jButtonSet.setPreferredSize(Dimension(55,25));
+        jPanel.add(jButtonSet, BorderLayout.EAST);
+    end
 
     % ==== MENU: 2DLAYOUT ====
     if strcmpi(FigureType, 'Topography') && strcmpi(GlobalData.DataSet(iDS).Figure(iFig).Id.SubType, '2DLayout')
@@ -1854,36 +1884,6 @@ function DisplayFigurePopup(hFig)
     if strcmpi(FigureType, 'Topography') && ~isempty(Modality) && (Modality(1) ~= '$') && (isempty(TsInfo) || isempty(TsInfo.RowNames))
         jMenuMontage = gui_component('Menu', jPopup, [], 'Montage', IconLoader.ICON_TS_DISPLAY_MODE);
         panel_montage('CreateFigurePopupMenu', jMenuMontage, hFig);
-    end
-
-    % ==== MENU: ISOSURFACE ====
-    % Create isosurface
-    iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
-    if ~isempty(iSurf)
-        % get the CT file details
-        SubjectFile = getappdata(hFig, 'SubjectFile');
-        sSubject = bst_get('Subject', SubjectFile);
-        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
-        CtFile = sSubject.Anatomy(iCt(1)).FileName;
-        sCt = bst_memory('LoadMri', CtFile);
-        % panel operations
-        jPanel = gui_component('Panel');
-        jPanel.setOpaque(0);
-        jPopup.add(jPanel);
-        % Title
-        jLabel = gui_component('label', [], '', '<HTML><B>isoValue </B>', IconLoader.ICON_SURFACE);
-        jPanel.add(jLabel, BorderLayout.WEST);
-        % Spin button
-        sSurface = bst_memory('LoadSurface', TessInfo(iSurf).SurfaceFile);
-        val = regexp(sSurface.Comment, '\d+', 'match');
-        spinmodel = SpinnerNumberModel(str2double(val(1)), double(sCt.Histogram.whiteLevel), double(sCt.Histogram.intensityMax), 50);
-        jSpinner = JSpinner(spinmodel);
-        jSpinner.setPreferredSize(Dimension(55,25));
-        % jSpinner.setToolTipText(strTooltip);
-        jPanel.add(jSpinner, BorderLayout.CENTER);
-        jButtonSet = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
-        jButtonSet.setPreferredSize(Dimension(55,25));
-        jPanel.add(jButtonSet, BorderLayout.EAST);
     end
 
     % ==== MENU: COLORMAPS ====

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1074,20 +1074,20 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                     % Get figure handle
                     Handles = bst_figures('GetFigureHandles', hFig);
                     % Check if there is SEEG isosurface displayed on the figure
-                    iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));      
+                    iIsoSurf = find(cellfun(@(x) ~isempty(regexp(x, '_isosurface', 'match')), {TessInfo.SurfaceFile}));      
                     % If there are tensors displayed: update display
                     if isfield(Handles, 'TensorDisplay') && ~isempty(Handles.TensorDisplay)
                         PlotTensorCut(hFig, [], [], [], keyEvent.Key, []);
                     % update isoValue threshold (Shift + Up/Down)
-                    elseif ismember('shift', keyEvent.Modifier) && ~isempty(iSurf)
+                    elseif ismember('shift', keyEvent.Modifier) && ~isempty(iIsoSurf)
                         % get the CT file and structure
                         SubjectFile = getappdata(hFig, 'SubjectFile');
                         sSubject = bst_get('Subject', SubjectFile);
-                        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+                        iCt = find(cellfun(@(x) ~isempty(regexp(x, '_volct', 'match')), {sSubject.Anatomy.FileName}));
                         CtFile = sSubject.Anatomy(iCt(1)).FileName;
                         sCt = bst_memory('LoadMri', CtFile);
                         % get the isosurface structure
-                        sSurface = bst_memory('LoadSurface', TessInfo(iSurf(1)).SurfaceFile);
+                        sSurface = bst_memory('LoadSurface', TessInfo(iIsoSurf(1)).SurfaceFile);
                         % get the current isoValue
                         val = regexp(sSurface.Comment, '\d+', 'match');
                         % increase/decrease isoValue by 100 for a coarse tuning by making sure it is in desired range

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1090,11 +1090,11 @@ function FigureKeyPressedCallback(hFig, keyEvent)
                         sSurface = bst_memory('LoadSurface', TessInfo(iIsoSurf(1)).SurfaceFile);
                         % get the current isoValue
                         val = regexp(sSurface.Comment, '\d+', 'match');
-                        % increase/decrease isoValue by 100 for a coarse tuning by making sure it is in desired range
+                        % increase/decrease isoValue by 300 for a coarse tuning by making sure it is in permissible range
                         if strcmpi(keyEvent.Key, 'uparrow')
-                            newVal = str2double(val(1)) + 100;
+                            newVal = str2double(val(1)) + 300;
                         else
-                            newVal = str2double(val(1)) - 100;
+                            newVal = str2double(val(1)) - 300;
                         end
                         if (newVal >= double(sCt.Histogram.whiteLevel)) && (newVal <= double(sCt.Histogram.intensityMax))
                            tess_isosurface(CtFile, newVal);
@@ -1693,16 +1693,16 @@ function DisplayFigurePopup(hFig)
     
     % ==== MENU: ISOSURFACE ====
     % Create isosurface
-    iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
-    if ~isempty(iSurf)
+    iIsoSurf = find(cellfun(@(x)(~isempty(regexp(x, '_isosurface', 'match'))), {TessInfo.SurfaceFile}));
+    if ~isempty(iIsoSurf)
         % get the CT file and its structure
         SubjectFile = getappdata(hFig, 'SubjectFile');
         sSubject = bst_get('Subject', SubjectFile);
-        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+        iCt = find(cellfun(@(x)(~isempty(regexp(x, '_volct', 'match'))), {sSubject.Anatomy.FileName}));
         CtFile = sSubject.Anatomy(iCt(1)).FileName;
         sCt = bst_memory('LoadMri', CtFile);
         % get the isosurface structure
-        sSurface = bst_memory('LoadSurface', TessInfo(iSurf).SurfaceFile);
+        sSurface = bst_memory('LoadSurface', TessInfo(iIsoSurf(1)).SurfaceFile);
         % panel operations
         jPanel = gui_component('Panel');
         jPanel.setOpaque(0);
@@ -1713,9 +1713,10 @@ function DisplayFigurePopup(hFig)
         % Spin button
         % get the current isoValue
         val = regexp(sSurface.Comment, '\d+', 'match');
+        % increase/decrease isoValue by 50 for a fine tuning making sure it is in permissible range
         spinmodel = SpinnerNumberModel(str2double(val(1)), double(sCt.Histogram.whiteLevel), double(sCt.Histogram.intensityMax), 50);
         jSpinner = JSpinner(spinmodel);
-        jSpinner.setPreferredSize(Dimension(55,25));
+        jSpinner.setPreferredSize(Dimension(70,25));
         jSpinner.setToolTipText('isoValue thresholding');
         java_setcb(spinmodel, 'StateChangedCallback', @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
         jPanel.add(jSpinner, BorderLayout.EAST);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1556,6 +1556,8 @@ end
 %% ===== POPUP MENU =====
 % Show a popup dialog about the target 3DViz figure
 function DisplayFigurePopup(hFig)
+    import java.awt.*;
+    import javax.swing.*;
     import java.awt.event.KeyEvent;
     import javax.swing.KeyStroke;
     import org.brainstorm.icon.*;
@@ -1854,6 +1856,37 @@ function DisplayFigurePopup(hFig)
         panel_montage('CreateFigurePopupMenu', jMenuMontage, hFig);
     end
     
+
+    % ==== MENU: ISOSURFACE ====
+    % Create isosurface
+    TessInfo = getappdata(hFig, 'Surface');
+    iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
+    if ~isempty(iSurf)
+        jPanel = gui_component('Panel');
+        jPanel.setOpaque(0);
+        jPopup.add(jPanel);
+        % Title
+        jLabel = gui_component('label', [], '', '<HTML><B>isoValue </B>', IconLoader.ICON_SURFACE);
+        jPanel.add(jLabel, BorderLayout.WEST);
+        % Spin button
+        sSurface = bst_memory('LoadSurface', TessInfo(iSurf).SurfaceFile);
+        val = regexp(sSurface.Comment, '\d+', 'match');
+        spinmodel = SpinnerNumberModel(str2double(val(1)), -4500, 4500, 50);
+        jSpinner = JSpinner(spinmodel);
+        jSpinner.setPreferredSize(Dimension(55,25));
+        % jSpinner.setToolTipText(strTooltip);
+        jPanel.add(jSpinner, BorderLayout.CENTER);
+        
+        SubjectFile = getappdata(hFig, 'SubjectFile');
+        sSubject = bst_get('Subject', SubjectFile);
+        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+        CtFile = sSubject.Anatomy(iCt(1)).FileName;
+        
+        jButton1 = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
+        jButton1.setPreferredSize(Dimension(55,25));
+        jPanel.add(jButton1, BorderLayout.EAST);
+    end
+
     % ==== MENU: COLORMAPS ====
     % Create the colormaps menus
     bst_colormaps('CreateAllMenus', jPopup, hFig, 0);

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1855,11 +1855,9 @@ function DisplayFigurePopup(hFig)
         jMenuMontage = gui_component('Menu', jPopup, [], 'Montage', IconLoader.ICON_TS_DISPLAY_MODE);
         panel_montage('CreateFigurePopupMenu', jMenuMontage, hFig);
     end
-    
 
     % ==== MENU: ISOSURFACE ====
     % Create isosurface
-    TessInfo = getappdata(hFig, 'Surface');
     iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
     if ~isempty(iSurf)
         % get the CT file details
@@ -1883,10 +1881,9 @@ function DisplayFigurePopup(hFig)
         jSpinner.setPreferredSize(Dimension(55,25));
         % jSpinner.setToolTipText(strTooltip);
         jPanel.add(jSpinner, BorderLayout.CENTER);
-        
-        jButton1 = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
-        jButton1.setPreferredSize(Dimension(55,25));
-        jPanel.add(jButton1, BorderLayout.EAST);
+        jButtonSet = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
+        jButtonSet.setPreferredSize(Dimension(55,25));
+        jPanel.add(jButtonSet, BorderLayout.EAST);
     end
 
     % ==== MENU: COLORMAPS ====

--- a/toolbox/gui/figure_3d.m
+++ b/toolbox/gui/figure_3d.m
@@ -1862,6 +1862,13 @@ function DisplayFigurePopup(hFig)
     TessInfo = getappdata(hFig, 'Surface');
     iSurf = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {TessInfo.SurfaceFile}));
     if ~isempty(iSurf)
+        % get the CT file details
+        SubjectFile = getappdata(hFig, 'SubjectFile');
+        sSubject = bst_get('Subject', SubjectFile);
+        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+        CtFile = sSubject.Anatomy(iCt(1)).FileName;
+        sCt = bst_memory('LoadMri', CtFile);
+        % panel operations
         jPanel = gui_component('Panel');
         jPanel.setOpaque(0);
         jPopup.add(jPanel);
@@ -1871,16 +1878,11 @@ function DisplayFigurePopup(hFig)
         % Spin button
         sSurface = bst_memory('LoadSurface', TessInfo(iSurf).SurfaceFile);
         val = regexp(sSurface.Comment, '\d+', 'match');
-        spinmodel = SpinnerNumberModel(str2double(val(1)), -4500, 4500, 50);
+        spinmodel = SpinnerNumberModel(str2double(val(1)), double(sCt.Histogram.whiteLevel), double(sCt.Histogram.intensityMax), 50);
         jSpinner = JSpinner(spinmodel);
         jSpinner.setPreferredSize(Dimension(55,25));
         % jSpinner.setToolTipText(strTooltip);
         jPanel.add(jSpinner, BorderLayout.CENTER);
-        
-        SubjectFile = getappdata(hFig, 'SubjectFile');
-        sSubject = bst_get('Subject', SubjectFile);
-        iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
-        CtFile = sSubject.Anatomy(iCt(1)).FileName;
         
         jButton1 = gui_component('button', [], '', 'Set', [], [], @(h,ev)tess_isosurface(CtFile, jSpinner.getValue()));
         jButton1.setPreferredSize(Dimension(55,25));

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -417,18 +417,12 @@ function SliderCallback(hObject, event, target)
             SubjectFile = getappdata(hFig, 'SubjectFile');
             if ~isempty(SubjectFile)
                 sSubject = bst_get('Subject', SubjectFile);
-                CtFile = [];
-                MeshFile = [];
-                for i=1:length(sSubject.Anatomy)
-                    if ~isempty(regexp(sSubject.Anatomy(i).FileName, 'CT', 'match')) 
-                        CtFile = sSubject.Anatomy(i).FileName;
-                    end
-                end
-                for i=1:length(sSubject.Surface)
-                    if ~isempty(regexp(sSubject.Surface(i).FileName, 'tess_isosurface', 'match')) 
-                        MeshFile = sSubject.Surface(i).FileName;
-                    end
-                end
+                % get the CT file
+                iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+                CtFile = sSubject.Anatomy(iCt(1)).FileName;                
+                % get the isosurface
+                iIsosurface = find(cellfun(@(c)(~isempty(strfind(char(c), 'tess_isosurface'))), {sSubject.Surface.FileName}));
+                MeshFile = sSubject.Surface(iIsosurface(1)).FileName;
             end
             
             % ask user if they want to proceed
@@ -536,12 +530,9 @@ function isoValue = GetIsoValueMaxRange()
         SubjectFile = getappdata(hFig, 'SubjectFile');
         if ~isempty(SubjectFile)
             sSubject = bst_get('Subject', SubjectFile);
-            CtFile = [];
-            for i=1:length(sSubject.Anatomy)
-                if ~isempty(regexp(sSubject.Anatomy(i).FileName, 'CT', 'match')) 
-                    CtFile = sSubject.Anatomy(i).FileName;
-                end
-            end
+            % get the CT file
+            iCt = find(cellfun(@(c)(~isempty(strfind(char(c), '_volct'))), {sSubject.Anatomy.FileName}));
+            CtFile = sSubject.Anatomy(iCt(1)).FileName;
         end
         
         if ~isempty(CtFile)

--- a/toolbox/gui/panel_surface.m
+++ b/toolbox/gui/panel_surface.m
@@ -438,7 +438,7 @@ function SliderCallback(hObject, event, target)
             isoValue = jSlider.getValue();
             
             % remove the old isosurface and generate and load the new one
-            ButtonRemoveSurfaceCallback();
+            % ButtonRemoveSurfaceCallback();
             tess_isosurface(CtFile, isoValue);
             
         case 'DataAlpha'

--- a/toolbox/tree/tree_callbacks.m
+++ b/toolbox/tree/tree_callbacks.m
@@ -226,12 +226,13 @@ switch (lower(action))
                 % Get displayable modalities for this file
                 [tmp, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
                 DisplayMod = intersect(DisplayMod, {'EEG','MEG','MEG GRAD','MEG MAG','ECOG','SEEG','ECOG+SEEG','NIRS'});
+                hFig = bst_figures('GetFiguresByType','3DViz');
                 % If only one modality
                 if ~isempty(DisplayMod)
                     if strcmpi(DisplayMod{1}, 'ECOG+SEEG') || (length(DisplayMod) >= 2) && all(ismember({'SEEG','ECOG'}, DisplayMod))
                         DisplayChannels(bstNodes, 'ECOG+SEEG', 'cortex', 1);
                     elseif strcmpi(DisplayMod{1}, 'SEEG')
-                        DisplayChannels(bstNodes, DisplayMod{1}, 'anatomy', 1, 0);
+                        DisplayChannels(bstNodes, DisplayMod{1}, 'anatomy', 1, 0, hFig);
                     elseif strcmpi(DisplayMod{1}, 'ECOG')
                         DisplayChannels(bstNodes, DisplayMod{1}, 'cortex', 1);
                     elseif ismember(DisplayMod{1}, {'MEG','MEG GRAD','MEG MAG'})
@@ -835,6 +836,7 @@ switch (lower(action))
                 % Get avaible modalities for this data file
                 [AllMod, DisplayMod] = bst_get('ChannelModalities', filenameRelative);
                 Device = bst_get('ChannelDevice', filenameRelative);
+                hFig = bst_figures('GetFiguresByType','3DViz');
                 % Replace SEEG+ECOG with iEEG
                 if ~isempty(AllMod) && all(ismember({'SEEG','ECOG'}, AllMod))
                     AllMod = cat(2, {'ECOG+SEEG'}, setdiff(AllMod, {'SEEG','ECOG'}));
@@ -923,7 +925,7 @@ switch (lower(action))
                 end
                 % === SEEG IMPLANTATION ===
                 if (length(bstNodes) == 1) && ((isempty(AllMod) && strcmpi(sStudy.Name, 'implantation')) || any(ismember({'SEEG','ECOG','ECOG+SEEG'}, AllMod)))
-                        gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)DisplayChannels(bstNodes, 'SEEG', 'anatomy', 1, 0));
+                        gui_component('MenuItem', jPopup, [], 'SEEG/ECOG implantation', IconLoader.ICON_SEEG_DEPTH, [], @(h,ev)DisplayChannels(bstNodes, 'SEEG', 'anatomy', 1, 0, hFig));
                 end
                 % === SEEG CONTACT LABELLING ===
                 if (length(bstNodes) == 1) && ~isempty(AllMod) && any(ismember({'SEEG','ECOG','ECOG+SEEG'}, AllMod))


### PR DESCRIPTION
 - [x] remove the threshold isosurface slider feature from `Surface` tab
 - [x] add a pop up UI or maybe a menu item to change isosurface mesh in the figure window itself
 - [x] remove deleting and regeneration of isosurface file rather just update the surface data in the already present file
 - [x] add keyboard shortcut (Shift+uparrow/downarrow) for isovalue change; menu option on popup for fine tuning isovalue
 - [x] verify working with >=R2016b (R2017a used at USC BCI for Polhemus work)
 
 Other related issues:
 - [x] for SEEG implantation, prevent loading multiple instances of the same figure (isosurface+MRI Viewer)
 
 @tmedani
